### PR TITLE
win32 hygiene

### DIFF
--- a/include/target.h
+++ b/include/target.h
@@ -150,6 +150,7 @@
 #  define AN_CONSOLE_ITALICS ""
 #  define AN_CONSOLE_BOLD ""
 
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 
 //thanks to Eklavya Sharma: http://www.cplusplus.com/articles/2ywTURfi/


### PR DESCRIPTION
Adding #define WIN32_LEAN_AND_MEAN should reduce compilation time a bit. Less used win32 headers won't be automatically included.