### PR TITLE
Change fmap to use generic sized intoiterator

### DIFF
--- a/src/llvm/mod.rs
+++ b/src/llvm/mod.rs
@@ -482,7 +482,7 @@ impl<'g> Generator<'g> {
         let typ = self.context.opaque_struct_type(&info.name);
         self.types.insert((id, args), typ.into());
 
-        let fields = fmap(&fields, |field| {
+        let fields = fmap(fields, |field| {
             let field_type = typechecker::bind_typevars(&field.field_type, &bindings, cache);
             self.convert_type(&field_type, cache)
         });
@@ -497,7 +497,7 @@ impl<'g> Generator<'g> {
     fn find_largest_union_variant<'c>(&mut self, variants: &[types::TypeConstructor<'c>], bindings: &TypeBindings,
         cache: &ModuleCache<'c>) -> Option<Vec<types::Type>>
     {
-        let variants: Vec<Vec<types::Type>> = fmap(&variants, |variant| {
+        let variants: Vec<Vec<types::Type>> = fmap(variants, |variant| {
             fmap(&variant.args, |arg| typechecker::bind_typevars(arg, &bindings, cache))
         });
 

--- a/src/nameresolution/mod.rs
+++ b/src/nameresolution/mod.rs
@@ -797,8 +797,8 @@ fn create_variants<'c>(vec: &Variants<'c>, parent_type_id: TypeInfoId,
         resolver: &mut NameResolver, cache: &mut ModuleCache<'c>) -> Vec<TypeConstructor<'c>> {
 
     let mut index = 0;
-    fmap(&vec, |(name, types, location)| {
-        let args = fmap(&types, |t| resolver.convert_type(cache, t));
+    fmap(vec, |(name, types, location)| {
+        let args = fmap(types, |t| resolver.convert_type(cache, t));
 
         let id = resolver.push_definition(&name, false, cache, *location);
         cache.definition_infos[id.0].typ = Some(create_variant_constructor_type(parent_type_id, args.clone(), cache));
@@ -812,7 +812,7 @@ type Fields<'c> = Vec<(String, ast::Type<'c>, Location<'c>)>;
 
 fn create_fields<'c>(vec: &Fields<'c>, resolver: &mut NameResolver, cache: &mut ModuleCache<'c>) -> Vec<Field<'c>> {
 
-    fmap(&vec, |(name, field_type, location)| {
+    fmap(vec, |(name, field_type, location)| {
         let field_type = resolver.convert_type(cache, field_type);
 
         Field { name: name.clone(), field_type, location: *location }

--- a/src/parser/pretty_printer.rs
+++ b/src/parser/pretty_printer.rs
@@ -124,7 +124,7 @@ impl<'a> Display for ast::TypeDefinitionBody<'a> {
                 Ok(())
             },
             StructOf(types) => {
-                let types = fmap(&types, |(name, ty, _)| format!("{}: {}", name, ty));
+                let types = fmap(types, |(name, ty, _)| format!("{}: {}", name, ty));
                 write!(f, "{}", types.join(", "))
             },
             AliasOf(alias) => write!(f, "{}", alias),

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -8,10 +8,12 @@ pub mod timing;
 pub mod trustme;
 
 /// Equivalent to .iter().map(f).collect()
-pub fn fmap<T, U, F>(array: &[T], f: F) -> Vec<U>
-    where F: FnMut(&T) -> U
+pub fn fmap<T, U, F>(iterable: T, f: F) -> Vec<U>
+    where 
+    T: IntoIterator,
+    F: FnMut(T::Item) -> U
 {
-    array.iter().map(f).collect()
+    iterable.into_iter().map(f).collect()
 }
 
 /// What a name! Iterate the array, mapping each element with a function that returns a pair
@@ -47,5 +49,5 @@ pub fn reinterpret_from_bits(x: u64) -> f64 {
 
 /// Convert each element to a String and join them with the given delimiter
 pub fn join_with<T: Display>(vec: &[T], delimiter: &str) -> String {
-    fmap(&vec, |t| format!("{}", t)).join(delimiter)
+    fmap(vec, |t| format!("{}", t)).join(delimiter)
 }


### PR DESCRIPTION
Regarding https://github.com/jfecher/ante/pull/73#discussion_r624719504

This seems to work without issues on existing code, and allows for `curried_function_call` to move the arguments. Does this look good to you? :)