### PR TITLE
Fix linker bug where input and output are the same path

### DIFF
--- a/src/cranelift_backend/context.rs
+++ b/src/cranelift_backend/context.rs
@@ -140,7 +140,7 @@ impl<'local> Context<'local> {
     }
 
     pub fn codegen_all(path: &Path, hir: &'local Ast, args: &Args) {
-        let output_path = path.with_extension("");
+        let output_path = path.with_extension("o");
         let (mut context, mut builder_context) = Context::new(&output_path, !args.build);
         let mut module_context = context.module.make_context();
 


### PR DESCRIPTION
This PR fixes a bug so cranelift backend works again. Previosuly, the input and output are the same path.