### PR TITLE
Add build.rs to set ANTE_STDLIB_DIR

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "ante"
 version = "0.1.1"
 authors = ["Jake Fecher <jfecher11@gmail.com>"]
 edition = "2018"
+build = "build.rs"
 
 [lib]
 name = "ante"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,42 @@
+#![allow(deprecated)]
+
+use std::env;
+use std::fs;
+use std::path;
+
+fn main() -> std::io::Result<()> {
+    // env::home_dir() is deprecated, maybe we should use dirs::home_dir()
+    let dot_ante = env::home_dir()
+        .expect("failed to get the location of the home dir")
+        .to_str()
+        .expect("invalid encoding of the home dir name")
+        .to_string()
+        + "/.ante";
+    if !path::Path::new(&dot_ante).exists() {
+        fs::create_dir(&dot_ante)
+            .expect("failed to create directory \".ante\"");
+        fs::create_dir(format!("{dot_ante}/stdlib"))
+            .expect("failed to create directory\".ante/stdlib\"");
+    }
+    println!("cargo:rustc-env=ANTE_STDLIB_DIR={dot_ante}/stdlib");
+    let mut stack = vec![path::PathBuf::from("stdlib")];
+    while let Some(dir) = stack.pop() {
+        for res in fs::read_dir(dir)? {
+            let entry = res?;
+            let p = entry.path();
+            if p.is_dir() {
+                let dirname = p.to_str().unwrap();
+                if !path::Path::new(&format!("{dot_ante}/{dirname}")).exists() {
+                    fs::create_dir(format!("{dot_ante}/{dirname}"))
+                        .expect(&format!("failed to create directory \"{dirname}\""));
+                }
+                stack.push(p);
+            } else {
+                let filename = p.to_str().unwrap();
+                fs::copy(&p, format!("{dot_ante}/{filename}"))
+                    .expect(&format!("failed to copy file \"{filename}\""));
+            }
+        }
+    }
+    Ok(())
+}

--- a/build.rs
+++ b/build.rs
@@ -1,42 +1,7 @@
-#![allow(deprecated)]
-
 use std::env;
-use std::fs;
-use std::path;
 
 fn main() -> std::io::Result<()> {
-    // env::home_dir() is deprecated, maybe we should use dirs::home_dir()
-    let dot_ante = env::home_dir()
-        .expect("failed to get the location of the home dir")
-        .to_str()
-        .expect("invalid encoding of the home dir name")
-        .to_string()
-        + "/.ante";
-    if !path::Path::new(&dot_ante).exists() {
-        fs::create_dir(&dot_ante)
-            .expect("failed to create directory \".ante\"");
-        fs::create_dir(format!("{dot_ante}/stdlib"))
-            .expect("failed to create directory\".ante/stdlib\"");
-    }
-    println!("cargo:rustc-env=ANTE_STDLIB_DIR={dot_ante}/stdlib");
-    let mut stack = vec![path::PathBuf::from("stdlib")];
-    while let Some(dir) = stack.pop() {
-        for res in fs::read_dir(dir)? {
-            let entry = res?;
-            let p = entry.path();
-            if p.is_dir() {
-                let dirname = p.to_str().unwrap();
-                if !path::Path::new(&format!("{dot_ante}/{dirname}")).exists() {
-                    fs::create_dir(format!("{dot_ante}/{dirname}"))
-                        .expect(&format!("failed to create directory \"{dirname}\""));
-                }
-                stack.push(p);
-            } else {
-                let filename = p.to_str().unwrap();
-                fs::copy(&p, format!("{dot_ante}/{filename}"))
-                    .expect(&format!("failed to copy file \"{filename}\""));
-            }
-        }
-    }
+    let cur_dir = env::current_dir()?;
+    println!("cargo:rustc-env=ANTE_STDLIB_DIR={}/stdlib", cur_dir.to_str().unwrap());
     Ok(())
 }

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,9 @@
 use std::env;
 
 fn main() -> std::io::Result<()> {
-    let cur_dir = env::current_dir()?;
-    println!("cargo:rustc-env=ANTE_STDLIB_DIR={}/stdlib", cur_dir.to_str().unwrap());
+    if option_env!("ANTE_STDLIB_DIR").is_none() {
+        let cur_dir = env::current_dir()?;
+        println!("cargo:rustc-env=ANTE_STDLIB_DIR={}/stdlib", cur_dir.to_str().unwrap());
+    }
     Ok(())
 }

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -73,14 +73,7 @@ pub fn binary_name(module_name: &str) -> String {
 pub fn stdlib_dir() -> PathBuf {
     match option_env!("ANTE_STDLIB_DIR") {
         Some(env) => std::fs::canonicalize(env).unwrap(),
-        None => {
-            let mut path = PathBuf::from(file!());
-            path.pop();
-            path.pop();
-            path.pop();
-            path.push("stdlib");
-            path.canonicalize().unwrap()
-        }
+        None => panic!("ANTE_STDLIB_DIR is not set"),
     }
 }
 


### PR DESCRIPTION
I ran the compiler somewhere other than the project root, and it crashed.

```console
$ ante test.an
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 3, kind: NotFound, message: "No such file or directory" }', src\util\mod.rs:82:33
stack backtrace:
...
```

The cause of it is `stdlib_dir()` in util/mod.rs.

```rust
pub fn stdlib_dir() -> PathBuf {
    match option_env!("ANTE_STDLIB_DIR") {
        Some(env) => std::fs::canonicalize(env).unwrap(),
        None => {
            let mut path = PathBuf::from(file!());
            path.pop();
            path.pop();
            path.pop();
            path.push("stdlib");
            path.canonicalize().unwrap()
        }
    }
}
```

This doesn't work if `ANTE_STDLIB_DIR` is not set and the compiler is executed other than the project root, since `file!()` doesn't return the absolute path.

So I created a build script that copies `stdlib` and sets `ANTE_STDLIB_DIR`.

For now, `stdlib` is located at `$HOME/.ante`. If you don't like this, tell me the appropriate location.
For reference, Rust's standard library is located at `.rustup/toolchains/<arch>/lib/rustlib`.
