### PR TITLE
Do nothing if the input file is empty

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -92,6 +92,9 @@ pub fn main() {
     let filename = Path::new(&args.file);
     let file = File::open(filename);
     let file = expect!(file, "Could not open file {}\n", filename.display());
+    if let Ok(0) = file.metadata().map(|data| data.len()) {
+        return;
+    }
 
     let mut cache = ModuleCache::new(filename.parent().unwrap());
 

--- a/src/nameresolution/mod.rs
+++ b/src/nameresolution/mod.rs
@@ -1106,7 +1106,12 @@ fn find_file(relative_path: &Path, cache: &mut ModuleCache) -> Option<(File, Pat
 
 pub fn declare_module<'a>(path: &Path, cache: &mut ModuleCache<'a>, error_location: Location<'a>) -> Option<ModuleId> {
     let (file, path) = match find_file(path, cache) {
-        Some((f, p)) => (f, p),
+        Some((f, p)) => {
+            if let Ok(0) = f.metadata().map(|data| data.len()) {
+                return None;
+            }
+            (f, p)
+        },
         _ => {
             error!(error_location, "Couldn't open file for import: {}.an", path.display());
             return None;


### PR DESCRIPTION
This is a trivial problem, but the compiler crashed when I tried to compile an empty file.

```console
$ ante empty.an
empty.an:1:1     error: failed trying to parse a term
thread 'main' panicked at 'called `Option::unwrap()` on a `None` value', src\error\mod.rs:203:79
stack backtrace:
...
```

In languages that do not have or require entry points, such as the main function, an empty file is often valid input and nothing is done as a result of execution.

So I've modified the compiler to immediately terminate if the input is an empty file.
