### PR TITLE
Add nix flake and package derivation

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,37 @@
+let
+  ante = ({ lib
+          , libffi
+          , libxml2
+          , llvmPackages
+          , ncurses
+          , rustPlatform
+          }:
+
+    rustPlatform.buildRustPackage {
+      pname = "ante";
+      version = "0.1.1";
+      src = ./.;
+      cargoSha256 = "WVNBk/5Q4tpMMQDNgRSSD4WFTOqgCPxa1YkBezqTaRI=";
+
+      nativeBuildInputs = [ llvmPackages.llvm ];
+      buildInputs = [ libffi libxml2 ncurses ];
+
+      postPatch = ''
+        substituteInPlace tests/golden_tests.rs --replace \
+          'target/debug' "target/$(rustc -vV | sed -n 's|host: ||p')/release"
+      '';
+      preBuild =
+        let
+          major = lib.versions.major llvmPackages.llvm.version;
+          minor = lib.versions.minor llvmPackages.llvm.version;
+          llvm-sys-ver = "${major}${builtins.substring 0 1 minor}";
+        in
+        ''
+          export LLVM_SYS_${llvm-sys-ver}_PREFIX=${llvmPackages.llvm.dev}
+          export ANTE_STDLIB_DIR=$out/lib
+          mkdir -p $ANTE_STDLIB_DIR
+          cp -r $src/stdlib/* $ANTE_STDLIB_DIR
+        '';
+    });
+in
+{ pkgs ? import <nixpkgs> { } }: with pkgs; callPackage ante { llvmPackages = llvmPackages_13; } 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,42 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1662911228,
+        "narHash": "sha256-oJOrB2lEeBLaO8g1DKG5PK9a1zyOWypkscrEfxxEj8A=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c97e777ff06fcb8d37dcdf5e21e9eff1f34f0e90",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,16 @@
+{
+  inputs = {
+    nixpkgs.url = "nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    { overlays.default = _: super: { ante = (import ./.) { pkgs = super; }; }; } //
+    (flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = nixpkgs.legacyPackages.${system}; in {
+        packages = rec {
+          ante = (import ./.) { inherit pkgs; };
+          default = ante;
+        };
+      }));
+}


### PR DESCRIPTION
#125
This provides a flake with `overlays` and `packages` for each default platform in its outputs, as well as a `default.nix` with the ante package derivation which should work with non nix-command cli.