### PR TITLE
Implemented string interpolation

### DIFF
--- a/examples/codegen/int_string_cast.an
+++ b/examples/codegen/int_string_cast.an
@@ -11,8 +11,11 @@ debug <| cast -1024
 
 debug <| cast 0
 
+debug <| cast 10
+
 // args: --delete-binary
 // expected stdout:
 // string: 255 len: 3
 // string: -1024 len: 5
 // string: 0 len: 1
+// string: 10 len: 2

--- a/examples/parsing/string_interpolation.an
+++ b/examples/parsing/string_interpolation.an
@@ -1,0 +1,19 @@
+shout x = "${x}!"
+
+bar = "nested interpolations"
+
+print
+  "I can do line breaks${
+    shout "\nAny expressions"
+  }${
+    shout "\nEven ${bar}"
+  }"
+
+// args: --parse
+// expected stdout:
+// (shout = (fn x -> ('++' "" ('++' (cast x) "!"))));
+// (bar = "nested interpolations");
+// (print ('++' ('++' "I can do line breaks" (cast (shout "
+// Any expressions"))) (cast (shout ('++' "
+// Even " (cast bar))))))
+

--- a/examples/parsing/string_interpolation.an
+++ b/examples/parsing/string_interpolation.an
@@ -11,7 +11,7 @@ print
 
 // args: --parse
 // expected stdout:
-// (shout = (fn x -> ('++' "" ('++' (cast x) "!"))));
+// (shout = (fn x -> ('++' (cast x) "!")));
 // (bar = "nested interpolations");
 // (print ('++' ('++' "I can do line breaks" (cast (shout "
 // Any expressions"))) (cast (shout ('++' "

--- a/examples/parsing/string_interpolation.an
+++ b/examples/parsing/string_interpolation.an
@@ -11,7 +11,7 @@ print
 
 // args: --parse
 // expected stdout:
-// (shout = (fn x -> ('++' (cast x) "!")));
+// (shout = (fn x -> (: ('++' (cast x) "!") string)));
 // (bar = "nested interpolations");
 // (print ('++' ('++' "I can do line breaks" (cast (shout "
 // Any expressions"))) (cast (shout ('++' "

--- a/src/lexer/token.rs
+++ b/src/lexer/token.rs
@@ -138,6 +138,8 @@ pub enum Token {
     Add,                // +
     BracketLeft,        // [
     BracketRight,       // ]
+    InterpolateLeft,    // ${
+    InterpolateRight,   // }
     Pipe,               // |
     Colon,              // :
     Semicolon,          // ;
@@ -312,6 +314,8 @@ impl Display for Token {
             Add => write!(f, "'+'"),
             BracketLeft => write!(f, "'['"),
             BracketRight => write!(f, "']'"),
+            InterpolateLeft => write!(f, "'${{'"),
+            InterpolateRight => write!(f, "'}}'"),
             Pipe => write!(f, "'|'"),
             Colon => write!(f, "':'"),
             Semicolon => write!(f, "';'"),

--- a/src/parser/desugar.rs
+++ b/src/parser/desugar.rs
@@ -143,6 +143,23 @@ pub fn desugar_handle_branches_into_matches<'a>(branches: Vec<(Ast<'a>, Ast<'a>)
     })
 }
 
+pub fn interpolate<'a>(lhs: Ast<'a>, rhs: Ast<'a>, location: Location<'a>) -> Ast<'a> {
+    let cast = Ast::variable(vec![], String::from("cast"), location);
+    let lhs = Ast::function_call(cast, vec![lhs], location);
+    match rhs {
+        Ast::Literal(super::ast::Literal { kind: ast::LiteralKind::String(s), .. }) if s.is_empty() => lhs,
+        _ => Ast::function_call(Ast::operator(Token::Append, location), vec![lhs, rhs], location),
+    }
+}
+
+pub fn concatenate_strings<'a>(head: Ast<'a>, tail: Vec<Ast<'a>>, location: Location<'a>) -> Ast<'a> {
+    let mut ret = head;
+    for expr in tail {
+        ret = Ast::function_call(Ast::operator(Token::Append, location), vec![ret, expr], location)
+    }
+    ret
+}
+
 /// Wrap all arguments in a tuple of nested pairs.
 /// This could be more efficient, using e.g. a VecDeque
 fn tuplify<'a>(mut args: Vec<Ast<'a>>, location: Location<'a>) -> Ast<'a> {

--- a/src/parser/desugar.rs
+++ b/src/parser/desugar.rs
@@ -173,7 +173,7 @@ pub fn concatenate_strings<'a>(head: Ast<'a>, tail: Vec<Ast<'a>>, location: Loca
             // Explicitly using the iterator rather than recursion,
             // since this optimisation can only apply to the head
             let mut ret = match head {
-                ast if empty_string_literal(&ast) => expr,
+                ast if empty_string_literal(&ast) => Ast::type_annotation(expr, ast::Type::String(location), location),
                 _ => append(head, expr, location),
             };
             for expr in tail {

--- a/stdlib/prelude.an
+++ b/stdlib/prelude.an
@@ -464,7 +464,7 @@ impl Cast int string given
       abs, sign_off = if i < 0 then (i * -1, 1) else (i, 0)
       len = loop abs (cmp = 10) ->
         next = cmp * 10 // Here to check for overflow
-        if abs > cmp and next > cmp
+        if abs >= cmp and next > cmp
         then 1 + recur abs next
         else 1
 


### PR DESCRIPTION
#91
- Fixed a bug with int to string casting where `10`, `100`, etc would get cast to `"0"`, `"00"`, etc.
- Fixed a bug where the lexer would continue beyond EOF if the closing quote was not found.
- Fixed a bug where the lexer escaped `\'` instead of `\"` which are used for string literals.
- Added two new lexer tokens for indicating a start and end of an interpolation.
- Strings are parsed as `StringLiteral` and an any number of `InterpolateLeft` `expression` `InterpolateRight` and `StringLiteral` pairs.
- Expressions can be interpolated into strings by wrapping them with `${}`.

---

I also want to drop empty string literals when doing interpolations since currently any interpolated expression is followed by a string literal, meaning `"${a}${b}${c}"` gets parsed to `('++' ('++' ('++' "" ('++' (cast a) "")) ('++' (cast b) "")) ('++' (cast c) ""))`