### PR TITLE
Interpolating strings by re-running lexer and parser

### DIFF
--- a/examples/codegen/int_string_cast.an
+++ b/examples/codegen/int_string_cast.an
@@ -11,8 +11,11 @@ debug <| cast -1024
 
 debug <| cast 0
 
+debug <| cast 10
+
 // args: --delete-binary
 // expected stdout:
 // string: 255 len: 3
 // string: -1024 len: 5
 // string: 0 len: 1
+// string: 10 len: 2

--- a/examples/parsing/string_interpolation.an
+++ b/examples/parsing/string_interpolation.an
@@ -1,0 +1,21 @@
+shout x = "${x}!"
+
+bar = "nested interpolations"
+
+print
+  "I can do line breaks${
+    shout "\nAny expressions"
+  }${
+    shout "\nEven ${bar}"
+  }"
+
+print "\${not interpolated} valid string o{-< ${ shout "\${nested not interpolated\" valid nested o{-< " }"
+
+// args: --parse
+// expected stdout:
+// (shout = (fn x -> (: ('++' (cast x) "!") string)));
+// (bar = "nested interpolations");
+// (print ('++' ('++' "I can do line breaks" (cast (shout "
+// Any expressions"))) (cast (shout ('++' "
+// Even " (cast bar))))));
+// (print ('++' "${not interpolated} valid string o{-< " (cast (shout "${nested not interpolated" valid nested o{-< "))))

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -704,7 +704,7 @@ parser!(variable loc =
 
 parser!(string loc =
     contents <- string_literal_token;
-    Ast::string(contents, loc)
+    desugar::interpolate(contents, loc)?
 );
 
 parser!(integer loc =

--- a/stdlib/prelude.an
+++ b/stdlib/prelude.an
@@ -464,7 +464,7 @@ impl Cast int string given
       abs, sign_off = if i < 0 then (i * -1, 1) else (i, 0)
       len = loop abs (cmp = 10) ->
         next = cmp * 10 // Here to check for overflow
-        if abs > cmp and next > cmp
+        if abs >= cmp and next > cmp
         then 1 + recur abs next
         else 1
 


### PR DESCRIPTION
#91
Alternative to #131.
This does not introduce any extra tokens to the lexer, and should keep the lexer logic simpler by moving the interpolation logic inside closures, and should hopefully be quite future proof. 

The downsides to this approach is doing extra computation, since each string gets read at least twice, and as long as error messages rely on explicit file line and column numbers being passed around, syntax errors inside interpolations might be not the most helpful.

The former should not be a massive problem, especially if we introduce a syntax for non-interpolated-non-escaped at some later point, and the latter can be fixed.