### PR TITLE
Make dev shell faster

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,16 +1,24 @@
 let
-  ante = ({ lib
-          , libffi
-          , libxml2
-          , llvmPackages
-          , ncurses
-          , rustPlatform
-          }:
+  ante =
+    { lib
+    , libffi
+    , libxml2
+    , llvmPackages
+    , ncurses
+    , rustPlatform
+    }:
+
+    let
+      major = lib.versions.major llvmPackages.llvm.version;
+      minor = lib.versions.minor llvmPackages.llvm.version;
+      llvm-sys-ver = "${major}${builtins.substring 0 1 minor}";
+      toml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+    in
 
     rustPlatform.buildRustPackage {
       pname = "ante";
-      version = "0.1.1";
       src = ./.;
+      inherit (toml.package) version;
       cargoSha256 = "WVNBk/5Q4tpMMQDNgRSSD4WFTOqgCPxa1YkBezqTaRI=";
 
       nativeBuildInputs = [ llvmPackages.llvm ];
@@ -20,18 +28,18 @@ let
         substituteInPlace tests/golden_tests.rs --replace \
           'target/debug' "target/$(rustc -vV | sed -n 's|host: ||p')/release"
       '';
-      preBuild =
-        let
-          major = lib.versions.major llvmPackages.llvm.version;
-          minor = lib.versions.minor llvmPackages.llvm.version;
-          llvm-sys-ver = "${major}${builtins.substring 0 1 minor}";
-        in
-        ''
-          export LLVM_SYS_${llvm-sys-ver}_PREFIX=${llvmPackages.llvm.dev}
-          export ANTE_STDLIB_DIR=$out/lib
-          mkdir -p $ANTE_STDLIB_DIR
-          cp -r $src/stdlib/* $ANTE_STDLIB_DIR
-        '';
-    });
+
+      shellHook = ''
+        export LLVM_SYS_${llvm-sys-ver}_PREFIX=${llvmPackages.llvm.dev}
+      '';
+
+      preBuild = ''
+        $shellHook
+        export ANTE_STDLIB_DIR=$out/lib
+        mkdir -p $ANTE_STDLIB_DIR
+        cp -r $src/stdlib/* $ANTE_STDLIB_DIR
+      '';
+    };
 in
-{ pkgs ? import <nixpkgs> { } }: with pkgs; callPackage ante { llvmPackages = llvmPackages_13; } 
+{ pkgs ? import <nixpkgs> { } }: with pkgs;
+callPackage ante { llvmPackages = llvmPackages_13; }


### PR DESCRIPTION
Running nix develop on the ante package directly would first build vendor package with the cargo dependencies, however using cargo inside the shell would still have cargo fetch and install dependencies inside the project, leading to double build of dependencies after each update to the Cargo lockfile.

I've instead created a default devShell output that only uses the inputs of the ante package and sets the LLVM_SYS and PATH env variabls. Beyond that I've done minor formatting updates.