### PR TITLE
Fix compile error in prelude/input + rename it

### DIFF
--- a/stdlib/prelude.an
+++ b/stdlib/prelude.an
@@ -679,9 +679,9 @@ read_char () : Maybe char =
         then None
         else Some (transmute c : char)
 
-// Read a single line from stdin
-read_line () : string =
-    buffer, len = loop (buffer = null ()) (len = 0) ->
+// Read a single line from stdin, returning (Some s) if we got at least 1 character or None otherwise
+read_line () : Maybe string =
+    line = loop (buffer = null ()) (len = 0) ->
         buffer2 = if len % 32 == 0
             then realloc buffer (len + 32)
             else buffer
@@ -692,13 +692,18 @@ read_line () : string =
 
                 if ch != '\n'
                     then recur buffer2 (len + 1)
-                    else buffer2, len
+                    else Some (buffer2, len)
 
-            | _ -> buffer2, len
+            | _ -> if len > 0
+                        then Some (buffer2, len)
+                        else None
 
 
-    array_insert buffer len '\0'
-    string buffer len
+    match line
+        | Some (buffer, len) ->
+            array_insert buffer len '\0'
+            Some (string buffer len)
+        | _ -> None
 
 /// Print a message then return user input
 input msg : string =

--- a/stdlib/prelude.an
+++ b/stdlib/prelude.an
@@ -675,7 +675,7 @@ next_line (f: InFile) : string =
     string (@cstr) len
 
 // Read a single line from stdin
-read_line : string =
+read_line () : string =
     buffer, len = loop (buffer = null ()) (len = 0) ->
         c = getchar ()
         buffer2 = if len % 32 == 0
@@ -692,6 +692,6 @@ read_line : string =
     string buffer len
 
 /// Print a message then return user input
-input_with_prompt msg : string =
+input msg : string =
     printne msg
     read_line

--- a/stdlib/prelude.an
+++ b/stdlib/prelude.an
@@ -11,7 +11,7 @@ extern
     // printf: Ptr char - ... -> unit
     puts: Ptr char -> i32
     putchar: char -> unit
-    getchar: unit -> char
+    getchar: unit -> i32
     exit: i32 -> never_returns
     malloc: usz -> Ptr a
     calloc: /*items:*/usz - /*size:*/usz -> Ptr a
@@ -649,19 +649,18 @@ next_char (f: InFile) : char =
 // TODO: Why is this being monomorphised twice?
 next_line (f: InFile) : string =
     if eof f then return ""
-    eof = cast 255 : char
 
     capacity = mut 32
     cstr = mut malloc @capacity
 
     len = loop (len = 0) ->
         c = next_char f
-        if c == eof then return len
+        if c < 0 then return len
 
         //Flag feof if eof occurs after terminating newline
         if c == '\n' then
             peek = next_char f
-            if peek != eof then ungetc (cast peek) f
+            if peek >= 0 then ungetc (cast peek) f
             return len
 
         if len + 1 >= @capacity then
@@ -674,19 +673,29 @@ next_line (f: InFile) : string =
     array_insert (@cstr) len '\0'
     string (@cstr) len
 
+read_char () : Maybe char =
+    c = getchar ()
+    if c < 0
+        then None
+        else Some (transmute c : char)
+
 // Read a single line from stdin
 read_line () : string =
     buffer, len = loop (buffer = null ()) (len = 0) ->
-        c = getchar ()
         buffer2 = if len % 32 == 0
             then realloc buffer (len + 32)
             else buffer
 
-        array_insert buffer2 len c
+        match read_char ()
+            | Some ch ->
+                array_insert buffer2 len ch
 
-        if c != '\n' and (transmute c : i8) >= 0
-        then recur buffer2 (len + 1)
-        else buffer2, len
+                if ch != '\n'
+                    then recur buffer2 (len + 1)
+                    else buffer2, len
+
+            | _ -> buffer2, len
+
 
     array_insert buffer len '\0'
     string buffer len

--- a/stdlib/prelude.an
+++ b/stdlib/prelude.an
@@ -684,7 +684,7 @@ read_line : string =
 
         array_insert buffer2 len c
 
-        if c != '\n'
+        if c != '\n' and (transmute c : i8) >= 0
         then recur buffer2 (len + 1)
         else buffer2, len
 

--- a/stdlib/prelude.an
+++ b/stdlib/prelude.an
@@ -674,23 +674,24 @@ next_line (f: InFile) : string =
     array_insert (@cstr) len '\0'
     string (@cstr) len
 
-
-
-/// Print a message then return user input
-input msg : string =
-    printne msg
-
+// Read a single line from stdin
+read_line : string =
     buffer, len = loop (buffer = null ()) (len = 0) ->
         c = getchar ()
         buffer2 = if len % 32 == 0
             then realloc buffer (len + 32)
             else buffer
 
-        buffer2#len := c
+        array_insert buffer2 len c
 
         if c != '\n'
         then recur buffer2 (len + 1)
         else buffer2, len
 
-    buffer#len := '\0'
+    array_insert buffer len '\0'
     string buffer len
+
+/// Print a message then return user input
+input_with_prompt msg : string =
+    printne msg
+    read_line


### PR DESCRIPTION
I ran into errors like this when trying to call `input` in the Prelude:

```
error: No impl found for Extract (Ptr char) usz (ref char)
    buffer#len := '\0'
```

This PR does the following:

* fixes the compile error by replacing `buffer#len` assignment in prelude/input with call to `array_insert` (with help from Ante's Discord chat -- thanks!)
* splits `input` into two functions: `input` and `read_line`, since you'll often want to read a line from stdin without printing a message every time
* adds a check for EOF so programs don't hang forever if empty streams are piped in