### PR TITLE
Clean up CLI help messages

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,8 @@
           inherit system;
           overlays = [ self.overlays.default ];
         };
-        inherit (pkgs) ante mkShell;
+        inherit (pkgs)
+          ante mkShell rust-analyzer clippy rustfmt;
       in
       {
         packages = {
@@ -25,6 +26,7 @@
         devShells.default = mkShell {
           name = "ante-dev";
           inputsFrom = [ ante ];
+          packages = [ rust-analyzer clippy rustfmt ];
           shellHook = ante.shellHook + ''
             export PATH=$PWD/target/debug:$PATH
           '';

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,20 +1,18 @@
-use clap::{ArgGroup, Parser, ValueEnum, ValueHint};
+use clap::{Parser, ValueEnum, ValueHint};
 use clap_complete::Shell;
 
 #[derive(Parser, Debug)]
-#[command(author, version, about, long_about = None)]
-#[command(group(
-        ArgGroup::new("complete_compile")
-        .required(true),
-))]
-pub struct Cli {
-    /// Generate shell completion for a given shell
-    #[arg(long, group = "complete_compile")]
-    pub shell_completion: Option<Shell>,
+pub struct Completions {
+    #[arg(long)]
+    pub shell_completion: Shell,
+}
 
+#[derive(Parser, Debug)]
+#[command(author, version, about, long_about = None)]
+pub struct Cli {
     /// Path to the source file
-    #[arg(group = "complete_compile", value_hint=ValueHint::FilePath)]
-    pub file: Option<String>,
+    #[arg(value_hint=ValueHint::FilePath)]
+    pub file: String,
 
     /// Print out the input file annotated with inferred lifetimes of heap allocations
     #[arg(long, short = 'L')]

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,7 @@ use std::fs::File;
 use std::io::{stdout, BufReader, Read};
 use std::path::Path;
 
-use crate::cli::{Backend, Cli};
+use crate::cli::{Backend, Cli, Completions};
 
 #[global_allocator]
 static ALLOCATOR: mimalloc::MiMalloc = mimalloc::MiMalloc;
@@ -93,18 +93,16 @@ macro_rules! expect {( $result:expr , $fmt_string:expr $( , $($msg:tt)* )? ) => 
 });}
 
 pub fn main() {
-    let args = Cli::parse();
-    if let Some(shell) = args.shell_completion {
-        print_completions(shell);
+    if let Ok(Completions { shell_completion }) = Completions::try_parse() {
+        print_completions(shell_completion);
     } else {
-        compile(args)
+        compile(Cli::parse())
     }
 }
 
 fn compile(args: Cli) {
     // Setup the cache and read from the first file
-    let filename = if let Some(filename) = &args.file { filename } else { "" };
-    let filename = Path::new(filename);
+    let filename = Path::new(&args.file);
     let file = File::open(filename);
     let file = expect!(file, "Could not open file {}\n", filename.display());
 


### PR DESCRIPTION
Currently invoking just the command `ante` brings up a somewhat confusing message:
```console
error: The following required arguments were not provided:
  <--shell-completion <SHELL_COMPLETION>|FILE>

Usage: ante <--shell-completion <SHELL_COMPLETION>|FILE>

For more information try '--help'
```
The information on how to generate shell_completions is not very relevant for the end user, as that is usually done during installation. I've moved the shell completion option to a separate parser which will hide it from both the generated completion scripts, and error and help messages for the cli.
```console
error: The following required arguments were not provided:
  <FILE>

Usage: ante <FILE>

For more information try '--help'
```

I've also added rust lsp tooling to the devShell, so that the dev environment has a version of them compiled with the same version of rustc as is being used for ante.