### PR TITLE
Update nix derivation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /target
 .vscode
+
+# Nix build artifacts
+/result

--- a/default.nix
+++ b/default.nix
@@ -20,7 +20,7 @@ let
       pname = "ante";
       src = ./.;
       inherit (toml.package) version;
-      cargoSha256 = "CsWiTDzXMWtnbNBLVSxH0YmXez3YZ+i/W+uPcpgIRDo=";
+      cargoHash = "sha256-Mn5LukLn9bz8Z4YTNEk4CK5ItYFRngoB7Zp9XJVhM74=";
 
       nativeBuildInputs = [ llvmPackages.llvm installShellFiles ];
       buildInputs = [ libffi libxml2 ncurses ];

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1662911228,
-        "narHash": "sha256-oJOrB2lEeBLaO8g1DKG5PK9a1zyOWypkscrEfxxEj8A=",
+        "lastModified": 1676300157,
+        "narHash": "sha256-1HjRzfp6LOLfcj/HJHdVKWAkX9QRAouoh6AjzJiIerU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c97e777ff06fcb8d37dcdf5e21e9eff1f34f0e90",
+        "rev": "545c7a31e5dedea4a6d372712a18e00ce097d462",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Pull request https://github.com/jfecher/ante/commit/fa2e464fb68aa6da1f1252daf14555b0b334dce3 updated `Cargo.lock`. With it came a dependency on `rustc` version `1.14` or higher. I've updated the vendored cargo dependency hash to address the former, and `flake.lock` to use a newer rev of `nixpkgs` to address the latter.