### PR TITLE
Add named constructor parsing

### DIFF
--- a/examples/parsing/named_constructor.an
+++ b/examples/parsing/named_constructor.an
@@ -1,0 +1,50 @@
+// Explicit names
+T with b = "one", a = 1
+
+T with
+    b = "one"
+    a = 1
+
+// Implicit names
+T with b, a
+
+T with
+    foo
+    bar
+
+// Path names
+T.U.V with a, b
+
+// Tuples and exotic indentation
+T with a = (1, 2)
+
+T with a = 1,
+    b = 3
+
+T with a = (1, 2),
+    b = (3, 4), c = 5,
+    d = 6
+
+T with foo,
+       bar,
+       baz
+
+T with
+    foo = ( 1
+          , 2
+          , 3
+          )
+    bar = "bar"
+
+// args: --parse
+// expected stdout:
+// (T with b = "one", a = 1);
+// (T with b = "one", a = 1);
+// (T with b = b, a = a);
+// (T with foo = foo, bar = bar);
+// (T.U.V with a = a, b = b);
+// (T with a = (',' 1 2));
+// (T with a = 1, b = 3);
+// (T with a = (',' 1 2), b = (',' 3 4), c = 5, d = 6);
+// (T with foo = foo, bar = bar, baz = baz);
+// (T with foo = (',' 1 (',' 2 3)), bar = "bar")

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -17,7 +17,7 @@
 use crate::cache::unsafecache::UnsafeCache;
 use crate::error::location::{Locatable, Location};
 use crate::nameresolution::NameResolver;
-use crate::parser::ast::{Ast, Definition, EffectDefinition, TraitDefinition, TraitImpl, Extern};
+use crate::parser::ast::{Ast, Definition, EffectDefinition, Extern, TraitDefinition, TraitImpl};
 use crate::types::traits::{ConstraintSignature, RequiredImpl, RequiredTrait, TraitConstraintId};
 use crate::types::{GeneralizedType, Kind, LetBindingLevel, TypeBinding};
 use crate::types::{Type, TypeInfo, TypeInfoBody, TypeInfoId, TypeVariableId};
@@ -605,11 +605,9 @@ impl<'a> ModuleCache<'a> {
 
     pub fn follow_typebindings_shallow<'b>(&'b self, typ: &'b Type) -> &'b Type {
         match typ {
-            Type::TypeVariable(id) => {
-                match &self.type_bindings[id.0] {
-                    TypeBinding::Bound(typ) => self.follow_typebindings_shallow(typ),
-                    TypeBinding::Unbound(_, _) => typ,
-                }
+            Type::TypeVariable(id) => match &self.type_bindings[id.0] {
+                TypeBinding::Bound(typ) => self.follow_typebindings_shallow(typ),
+                TypeBinding::Unbound(_, _) => typ,
             },
             other => other,
         }

--- a/src/cranelift_backend/builtin.rs
+++ b/src/cranelift_backend/builtin.rs
@@ -140,7 +140,9 @@ fn eq_bool(param1: CraneliftValue, param2: CraneliftValue, builder: &mut Functio
     b1_to_i8(builder.ins().icmp(IntCC::Equal, param1, param2), builder)
 }
 
-fn transmute<'a>(context: &mut Context<'a>, param: &'a Ast, typ: &crate::hir::Type, builder: &mut FunctionBuilder) -> Value {
+fn transmute<'a>(
+    context: &mut Context<'a>, param: &'a Ast, typ: &crate::hir::Type, builder: &mut FunctionBuilder,
+) -> Value {
     let value = param.codegen(context, builder);
     context.transmute(value, typ, builder)
 }

--- a/src/cranelift_backend/module.rs
+++ b/src/cranelift_backend/module.rs
@@ -45,8 +45,7 @@ impl DynModule {
             DynModule::Jit(module) => {
                 module.finalize_definitions();
             },
-            DynModule::Static(_module) => {
-            },
+            DynModule::Static(_module) => {},
         }
     }
 

--- a/src/hir/definitions.rs
+++ b/src/hir/definitions.rs
@@ -91,8 +91,7 @@ fn definition_type_eq(a: &types::Type, b: &types::Type) -> bool {
     match (a, b) {
         (Type::Primitive(primitive1), Type::Primitive(primitive2)) => primitive1 == primitive2,
         (Type::UserDefined(id1), Type::UserDefined(id2)) => id1 == id2,
-        (Type::TypeVariable(_), Type::TypeVariable(_))
-        | (Type::Ref(_), Type::Ref(_)) => true, // Do nothing
+        (Type::TypeVariable(_), Type::TypeVariable(_)) | (Type::Ref(_), Type::Ref(_)) => true, // Do nothing
         (Type::Function(f1), Type::Function(f2)) => {
             if f1.parameters.len() != f2.parameters.len() {
                 return false;
@@ -113,7 +112,10 @@ fn definition_type_eq(a: &types::Type, b: &types::Type) -> bool {
             if field_names1.len() != field_names2.len() {
                 return false;
             }
-            field_names1.iter().zip(field_names2).all(|((name1, t1), (name2, t2))| name1 == name2 && definition_type_eq(t1, t2))
+            field_names1
+                .iter()
+                .zip(field_names2)
+                .all(|((name1, t1), (name2, t2))| name1 == name2 && definition_type_eq(t1, t2))
         },
         (Type::Effects(set1), Type::Effects(set2)) => {
             if set1.effects.len() != set2.effects.len() {
@@ -123,13 +125,12 @@ fn definition_type_eq(a: &types::Type, b: &types::Type) -> bool {
                 if args1.len() != args2.len() {
                     return false;
                 }
-                id1 == id2 &&
-                    args1.iter().zip(args2).all(|(t1, t2)| definition_type_eq(t1, t2))
+                id1 == id2 && args1.iter().zip(args2).all(|(t1, t2)| definition_type_eq(t1, t2))
             })
         },
         (othera, otherb) => {
             assert_ne!(std::mem::discriminant(othera), std::mem::discriminant(otherb), "ICE: Missing match case");
             false
-        }
+        },
     }
 }

--- a/src/hir/monomorphisation.rs
+++ b/src/hir/monomorphisation.rs
@@ -1452,10 +1452,11 @@ impl<'c> Context<'c> {
             // This case should only happen when a bottom type is unified with an anonymous field
             // type. Default to alphabetically ordered fields, but it should never actually be
             // accessed anyway.
-            Struct(fields, _binding) => {
-                fields.keys().position(|name| name == field_name)
-                    .expect(&format!("Expected type {} to have a field named '{}'", typ.display(&self.cache), field_name)) as u32
-            }
+            Struct(fields, _binding) => fields.keys().position(|name| name == field_name).expect(&format!(
+                "Expected type {} to have a field named '{}'",
+                typ.display(&self.cache),
+                field_name
+            )) as u32,
             _ => unreachable!(
                 "get_field_index called with type {} that doesn't have a '{}' field",
                 typ.display(&self.cache),

--- a/src/hir/monomorphisation.rs
+++ b/src/hir/monomorphisation.rs
@@ -130,6 +130,7 @@ impl<'c> Context<'c> {
             Assignment(assignment) => self.monomorphise_assignment(assignment),
             EffectDefinition(_) => todo!(),
             Handle(_) => todo!(),
+            NamedConstructor(_) => todo!(),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -167,8 +167,7 @@ fn compile(args: Cli) {
 
     // Phase 6: Codegen
     let default_backend = if args.opt_level == '0' { Backend::Cranelift } else { Backend::Llvm };
-    let backend =
-        args.backend.unwrap_or(default_backend);
+    let backend = args.backend.unwrap_or(default_backend);
 
     match backend {
         Backend::Cranelift => cranelift_backend::run(filename, hir, &args),

--- a/src/nameresolution/mod.rs
+++ b/src/nameresolution/mod.rs
@@ -1642,3 +1642,11 @@ impl<'c> Resolvable<'c> for ast::Handle<'c> {
         }
     }
 }
+
+impl<'c> Resolvable<'c> for ast::NamedConstructor<'c> {
+    fn declare(&mut self, _resolver: &mut NameResolver, _cache: &mut ModuleCache<'c>) {}
+
+    fn define(&mut self, _resolver: &mut NameResolver, _cache: &mut ModuleCache<'c>) {
+        todo!()
+    }
+}

--- a/src/nameresolution/mod.rs
+++ b/src/nameresolution/mod.rs
@@ -335,7 +335,9 @@ impl NameResolver {
         id
     }
 
-    fn push_new_type_variable<'c>(&mut self, key: &str, location: Location<'c>, cache: &mut ModuleCache<'c>) -> TypeVariableId {
+    fn push_new_type_variable<'c>(
+        &mut self, key: &str, location: Location<'c>, cache: &mut ModuleCache<'c>,
+    ) -> TypeVariableId {
         let id = cache.next_type_variable_id(self.let_binding_level);
         self.push_existing_type_variable(key, id, location)
     }
@@ -544,12 +546,22 @@ impl NameResolver {
         None
     }
 
-    fn validate_type_application<'c>(&self, constructor: &Type, args: &[Type], location: Location<'c>, cache: &mut ModuleCache<'c>) {
+    fn validate_type_application<'c>(
+        &self, constructor: &Type, args: &[Type], location: Location<'c>, cache: &mut ModuleCache<'c>,
+    ) {
         let expected = self.get_expected_type_argument_count(constructor, cache);
         if args.len() != expected && !matches!(constructor, Type::TypeVariable(_)) {
             let plural_s = if expected == 1 { "" } else { "s" };
             let is_are = if args.len() == 1 { "is" } else { "are" };
-            error!(location, "Type {} expects {} argument{}, but {} {} given here", constructor.display(cache), expected, plural_s, args.len(), is_are);
+            error!(
+                location,
+                "Type {} expects {} argument{}, but {} {} given here",
+                constructor.display(cache),
+                expected,
+                plural_s,
+                args.len(),
+                is_are
+            );
         }
 
         // Check argument is an integer/float type (issue #146)
@@ -564,7 +576,7 @@ impl NameResolver {
                     if !matches!(first_arg, Type::Primitive(PrimitiveType::FloatTag(_)) | Type::TypeVariable(_)) {
                         error!(location, "Type {} is not a float type", first_arg.display(cache));
                     }
-                }
+                },
                 _ => (),
             }
         }
@@ -590,7 +602,9 @@ impl NameResolver {
     /// Re-insert the given type variables into the current scope.
     /// Currently used for remembering type variables from type and trait definitions that
     /// were created in the declare pass and need to be used later in the define pass.
-    fn add_existing_type_variables_to_scope(&mut self, existing_typevars: &[String], ids: &[TypeVariableId], location: Location) {
+    fn add_existing_type_variables_to_scope(
+        &mut self, existing_typevars: &[String], ids: &[TypeVariableId], location: Location,
+    ) {
         // re-insert the typevars into scope.
         // These names are guarenteed to not collide since we just pushed a new scope.
         assert_eq!(existing_typevars.len(), ids.len());
@@ -692,11 +706,8 @@ impl<'c> NameResolver {
             ast::Type::Function(args, ret, is_varargs, is_closure, _) => {
                 let parameters = fmap(args, |arg| self.convert_type(cache, arg));
                 let return_type = Box::new(self.convert_type(cache, ret));
-                let environment = Box::new(if *is_closure {
-                    cache.next_type_variable(self.let_binding_level)
-                } else {
-                    Type::UNIT
-                });
+                let environment =
+                    Box::new(if *is_closure { cache.next_type_variable(self.let_binding_level) } else { Type::UNIT });
                 let effects = Box::new(cache.next_type_variable(self.let_binding_level));
                 let is_varargs = *is_varargs;
                 Type::Function(FunctionType { parameters, return_type, environment, is_varargs, effects })

--- a/src/parser/desugar.rs
+++ b/src/parser/desugar.rs
@@ -204,11 +204,5 @@ pub fn desugar_if_with_no_else<'a>(condition: Ast<'a>, then: Ast<'a>, location: 
     let then = Box::new(Ast::sequence(vec![then, Ast::unit_literal(location)], location));
     let otherwise = Box::new(Ast::unit_literal(location));
 
-    Ast::If(ast::If {
-        condition: Box::new(condition),
-        then,
-        otherwise,
-        location,
-        typ: None,
-    })
+    Ast::If(ast::If { condition: Box::new(condition), then, otherwise, location, typ: None })
 }

--- a/src/parser/pretty_printer.rs
+++ b/src/parser/pretty_printer.rs
@@ -272,3 +272,10 @@ impl<'a> Display for ast::Handle<'a> {
         write!(f, ")")
     }
 }
+
+impl<'a> Display for ast::NamedConstructor<'a> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let args = fmap(self.args.iter(), |(name, expr)| format!("{name} = {expr}"));
+        write!(f, "({} with {})", self.constructor, args.join(", "))
+    }
+}

--- a/src/types/pattern.rs
+++ b/src/types/pattern.rs
@@ -922,9 +922,13 @@ impl Case {
                 constructor_type.instantiate(vec![], cache).0
             },
             Some(Literal(LiteralKind::Integer(_, Some(kind)))) => Type::int(*kind),
-            Some(Literal(LiteralKind::Integer(_, None))) => Type::polymorphic_int(typechecker::next_type_variable_id(cache)),
+            Some(Literal(LiteralKind::Integer(_, None))) => {
+                Type::polymorphic_int(typechecker::next_type_variable_id(cache))
+            },
             Some(Literal(LiteralKind::Float(_, Some(kind)))) => Type::float(*kind),
-            Some(Literal(LiteralKind::Float(_, None))) => Type::polymorphic_float(typechecker::next_type_variable_id(cache)),
+            Some(Literal(LiteralKind::Float(_, None))) => {
+                Type::polymorphic_float(typechecker::next_type_variable_id(cache))
+            },
             Some(Literal(LiteralKind::String(_))) => Type::UserDefined(STRING_TYPE),
             Some(Literal(LiteralKind::Char(_))) => Type::Primitive(PrimitiveType::CharType),
             Some(Literal(LiteralKind::Bool(_))) => unreachable!(),

--- a/src/types/traitchecker.rs
+++ b/src/types/traitchecker.rs
@@ -20,14 +20,14 @@
 use std::sync::atomic::AtomicBool;
 
 use crate::cache::{ImplInfoId, ModuleCache};
-use crate::lexer::token::{IntegerKind, FloatKind};
+use crate::lexer::token::{FloatKind, IntegerKind};
 use crate::types::traits::{RequiredTrait, TraitConstraint, TraitConstraints};
 use crate::types::typechecker::{self, TypeBindings};
 use crate::types::TypeVariableId;
 use crate::util::{fmap, trustme};
 
-use super::{Type, PrimitiveType};
 use super::typechecker::UnificationBindings;
+use super::{PrimitiveType, Type};
 
 /// Arbitrary impl requirements can result in arbitrary recursion
 /// when attempting to solve impl constraints. To prevent infinitely
@@ -49,8 +49,7 @@ const DEFAULT_FLOAT_TYPE: Type = Type::Primitive(PrimitiveType::FloatTag(FloatKi
 pub fn resolve_traits<'a>(
     constraints: TraitConstraints, typevars_in_fn_signature: &[TypeVariableId], cache: &mut ModuleCache<'a>,
 ) -> Vec<RequiredTrait> {
-    let (propagated_traits, other_constraints) =
-        sort_traits(constraints, typevars_in_fn_signature, cache);
+    let (propagated_traits, other_constraints) = sort_traits(constraints, typevars_in_fn_signature, cache);
 
     let mut failing_constraints = try_solve_constraints(other_constraints.iter(), cache, false);
 
@@ -79,7 +78,9 @@ pub fn resolve_traits<'a>(
 }
 
 /// Attempt to solve each trait, returning each trait that failed to be solved
-fn try_solve_constraints<'a>(constraints: impl IntoIterator<Item = &'a TraitConstraint>, cache: &mut ModuleCache, default_to_i32: bool) -> Vec<&'a TraitConstraint> {
+fn try_solve_constraints<'a>(
+    constraints: impl IntoIterator<Item = &'a TraitConstraint>, cache: &mut ModuleCache, default_to_i32: bool,
+) -> Vec<&'a TraitConstraint> {
     constraints
         .into_iter()
         .filter_map(|constraint| {
@@ -106,18 +107,20 @@ fn default_polymorphic_literals(args: &[super::Type], cache: &ModuleCache) -> Un
 
 fn default_literals(arg: &Type, bindings: &mut UnificationBindings, cache: &ModuleCache) {
     // Check for every type application of the `Int` or `Float` type and an unbound type variable.
-    arg.traverse(cache, |typ| if let Type::TypeApplication(constructor, args) = typ {
-        let constructor = cache.follow_typebindings_shallow(constructor);
-        if let Type::Primitive(PrimitiveType::IntegerType) = &constructor {
-            let arg = cache.follow_typebindings_shallow(&args[0]);
-            if let Type::TypeVariable(id) = arg {
-                // bind id to i32
-                bindings.bindings.insert(*id, DEFAULT_INT_TYPE);
-            }
-        } else if let Type::Primitive(PrimitiveType::FloatType) = &constructor {
-            let arg = cache.follow_typebindings_shallow(&args[0]);
-            if let Type::TypeVariable(id) = arg {
-                bindings.bindings.insert(*id, DEFAULT_FLOAT_TYPE);
+    arg.traverse(cache, |typ| {
+        if let Type::TypeApplication(constructor, args) = typ {
+            let constructor = cache.follow_typebindings_shallow(constructor);
+            if let Type::Primitive(PrimitiveType::IntegerType) = &constructor {
+                let arg = cache.follow_typebindings_shallow(&args[0]);
+                if let Type::TypeVariable(id) = arg {
+                    // bind id to i32
+                    bindings.bindings.insert(*id, DEFAULT_INT_TYPE);
+                }
+            } else if let Type::Primitive(PrimitiveType::FloatType) = &constructor {
+                let arg = cache.follow_typebindings_shallow(&args[0]);
+                if let Type::TypeVariable(id) = arg {
+                    bindings.bindings.insert(*id, DEFAULT_FLOAT_TYPE);
+                }
             }
         }
     })

--- a/src/types/typechecker.rs
+++ b/src/types/typechecker.rs
@@ -2077,3 +2077,9 @@ impl<'a> Inferable<'a> for ast::Handle<'a> {
         result
     }
 }
+
+impl<'a> Inferable<'a> for ast::NamedConstructor<'a> {
+    fn infer_impl(&mut self, _checker: &mut ModuleCache<'a>) -> TypeResult {
+        todo!()
+    }
+}

--- a/src/types/typechecker.rs
+++ b/src/types/typechecker.rs
@@ -1476,7 +1476,7 @@ impl<'a> Inferable<'a> for ast::Literal<'a> {
                     Type::polymorphic_int(next_type_variable_id(cache))
                 };
                 TypeResult::of(t, cache)
-            }
+            },
             Float(_, kind) => {
                 let t = if let Some(kind) = kind {
                     Type::float(kind)
@@ -1484,7 +1484,7 @@ impl<'a> Inferable<'a> for ast::Literal<'a> {
                     Type::polymorphic_float(next_type_variable_id(cache))
                 };
                 TypeResult::of(t, cache)
-            }
+            },
             String(_) => TypeResult::of(Type::UserDefined(STRING_TYPE), cache),
             Char(_) => TypeResult::of(Type::Primitive(PrimitiveType::CharType), cache),
             Bool(_) => TypeResult::of(Type::Primitive(PrimitiveType::BooleanType), cache),

--- a/src/types/typed.rs
+++ b/src/types/typed.rs
@@ -52,3 +52,4 @@ impl_typed_for!(MemberAccess);
 impl_typed_for!(Assignment);
 impl_typed_for!(EffectDefinition);
 impl_typed_for!(Handle);
+impl_typed_for!(NamedConstructor);

--- a/src/types/typeprinter.rs
+++ b/src/types/typeprinter.rs
@@ -268,7 +268,7 @@ impl<'a, 'b> TypePrinter<'a, 'b> {
                 self.fmt_type(&args[0], f)?;
                 write!(f, "{}", ")".blue())
             },
-            other => self.fmt_type(other, f)
+            other => self.fmt_type(other, f),
         }
     }
 


### PR DESCRIPTION
Addresses the parsing part of #163.
I recommend looking only at the second commit, the first is just noise. Feel free to cherry-pick only the second one. I included it because `rustfmt` is automatically applied for me.

I tried to cover all the edge cases in `examples/parsing/named_constructor.an` but if I missed or misunderstood something feel free to point it out.