### PR TITLE
Switch to flake-parts and nci

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/crates.nix
+++ b/crates.nix
@@ -1,0 +1,52 @@
+{ ... }: {
+  perSystem = { pkgs, lib, ... }: {
+    nci =
+      let
+        llvmPackages = pkgs.llvmPackages_16;
+        major = lib.versions.major llvmPackages.llvm.version;
+        minor = lib.versions.minor llvmPackages.llvm.version;
+        llvm-sys-ver = "${major}${builtins.substring 0 1 minor}";
+        env = {
+          "LLVM_SYS_${llvm-sys-ver}_PREFIX" = llvmPackages.llvm.dev;
+        };
+      in
+      {
+        projects.ante.path = ./.;
+        crates.ante = {
+          depsDrvConfig = {
+            inherit env;
+          };
+          drvConfig = {
+            inherit env;
+            mkDerivation = {
+              nativeBuildInputs = [ pkgs.installShellFiles ];
+              buildInputs = lib.attrValues
+                {
+                  inherit (pkgs)
+                    libffi
+                    libxml2
+                    ncurses;
+                } ++ [ llvmPackages.llvm ];
+
+              postPatch = ''
+                substituteInPlace tests/golden_tests.rs --replace \
+                  'target/debug' "target/$(rustc -vV | sed -n 's|host: ||p')/release"
+              '';
+
+              preBuild = ''
+                export ANTE_STDLIB_DIR=$out/lib
+                find stdlib -type f -exec install -Dm644 "{}" -t $ANTE_STDLIB_DIR \;
+              '';
+
+              postInstall = ''
+                installShellCompletion --cmd ante \
+                  --bash <($out/bin/ante --shell-completion bash) \
+                  --fish <($out/bin/ante --shell-completion fish) \
+                  --zsh <($out/bin/ante --shell-completion zsh)
+              '';
+            };
+          };
+        };
+      };
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,39 +1,214 @@
 {
   "nodes": {
-    "flake-utils": {
+    "crane": {
+      "flake": false,
       "locked": {
-        "lastModified": 1676283394,
-        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "lastModified": 1686108916,
+        "narHash": "sha256-looLH5MdY4erLiJw0XwQohGdr0fJL9y6TJY3898RA2U=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "8ab1a49432695bd80ff4b7f6c6515da0e926d922",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "owner": "ipetkov",
+        "ref": "v0.12.2",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "dream2nix": {
+      "inputs": {
+        "devshell": [
+          "nci"
+        ],
+        "flake-compat": [
+          "nci"
+        ],
+        "flake-parts": [
+          "nci",
+          "parts"
+        ],
+        "nix-unit": [
+          "nci"
+        ],
+        "nixpkgs": [
+          "nci",
+          "nixpkgs"
+        ],
+        "pre-commit-hooks": [
+          "nci"
+        ]
+      },
+      "locked": {
+        "lastModified": 1697583627,
+        "narHash": "sha256-z699xvqroY17DsXzVpgaRVadD//g1bQnP26JUnJC7sI=",
+        "owner": "nix-community",
+        "repo": "dream2nix",
+        "rev": "c3e07bf838696baa280483e53ef6b369c4e58c45",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "dream2nix",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "locked": {
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "revCount": 57,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.0.1/018afb31-abd1-7bff-a5e4-cff7e18efb7a/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
+      }
+    },
+    "mk-naked-shell": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1681286841,
+        "narHash": "sha256-3XlJrwlR0nBiREnuogoa5i1b4+w/XPe0z8bbrJASw0g=",
+        "owner": "yusdacra",
+        "repo": "mk-naked-shell",
+        "rev": "7612f828dd6f22b7fb332cc69440e839d7ffe6bd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "yusdacra",
+        "repo": "mk-naked-shell",
+        "type": "github"
+      }
+    },
+    "nci": {
+      "inputs": {
+        "crane": "crane",
+        "dream2nix": "dream2nix",
+        "mk-naked-shell": "mk-naked-shell",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "parts": "parts",
+        "rust-overlay": "rust-overlay",
+        "treefmt": "treefmt"
+      },
+      "locked": {
+        "lastModified": 1697609510,
+        "narHash": "sha256-Q3iMP+kKqeutbBwfTPY/2BvnvxZa3vwZJqlOCThqRWY=",
+        "owner": "yusdacra",
+        "repo": "nix-cargo-integration",
+        "rev": "86671722cfdcf2e883db20d7efb7a3c9dfd32565",
+        "type": "github"
+      },
+      "original": {
+        "owner": "yusdacra",
+        "repo": "nix-cargo-integration",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1676300157,
-        "narHash": "sha256-1HjRzfp6LOLfcj/HJHdVKWAkX9QRAouoh6AjzJiIerU=",
-        "owner": "NixOS",
+        "lastModified": 1697456312,
+        "narHash": "sha256-roiSnrqb5r+ehnKCauPLugoU8S36KgmWraHgRqVYndo=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "545c7a31e5dedea4a6d372712a18e00ce097d462",
+        "rev": "ca012a02bf8327be9e488546faecae5e05d7d749",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
+        "owner": "nixos",
         "ref": "nixos-unstable",
-        "type": "indirect"
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nci",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1696343447,
+        "narHash": "sha256-B2xAZKLkkeRFG5XcHHSXXcP7To9Xzr59KXeZiRf4vdQ=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "c9afaba3dfa4085dbd2ccb38dfade5141e33d9d4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "parts_2": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1696343447,
+        "narHash": "sha256-B2xAZKLkkeRFG5XcHHSXXcP7To9Xzr59KXeZiRf4vdQ=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "c9afaba3dfa4085dbd2ccb38dfade5141e33d9d4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
       }
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "flake-compat": "flake-compat",
+        "nci": "nci",
+        "nixpkgs": "nixpkgs",
+        "parts": "parts_2"
+      }
+    },
+    "rust-overlay": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1697595136,
+        "narHash": "sha256-9honwiIeMbBKi7FzfEy89f1ShUiXz/gVxZSS048pKyc=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "a2ccfb2134622b28668a274e403ba6f075ae1223",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "treefmt": {
+      "inputs": {
+        "nixpkgs": [
+          "nci",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1697388351,
+        "narHash": "sha256-63N2eBpKaziIy4R44vjpUu8Nz5fCJY7okKrkixvDQmY=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "aae39f64f5ecbe89792d05eacea5cb241891292a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,35 +1,42 @@
 {
   inputs = {
-    nixpkgs.url = "nixpkgs/nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
+    flake-compat.url = "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    nci = {
+      url = "github:yusdacra/nix-cargo-integration";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
-    {
-      overlays.default = _: prev:
-        { ante = (import ./.) { pkgs = prev; }; };
-    } //
-    (flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = import nixpkgs {
-          inherit system;
-          overlays = [ self.overlays.default ];
+  outputs = inputs@{ parts, nci, ... }:
+    parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      imports = [
+        parts.flakeModules.easyOverlay
+        nci.flakeModule
+        ./crates.nix
+      ];
+
+      perSystem = { config, ... }:
+        let crateOutputs = config.nci.outputs.ante; in
+        {
+          overlayAttrs.ante = config.packages.default;
+          packages.default = crateOutputs.packages.release;
+          devShells.default = crateOutputs.devShell.overrideAttrs (_: {
+            shellHook = ''
+              PATH=$PATH:$PWD/target/debug
+            '';
+          });
         };
-        inherit (pkgs)
-          ante mkShell rust-analyzer clippy rustfmt;
-      in
-      {
-        packages = {
-          inherit ante;
-          default = ante;
-        };
-        devShells.default = mkShell {
-          name = "ante-dev";
-          inputsFrom = [ ante ];
-          packages = [ rust-analyzer clippy rustfmt ];
-          shellHook = ante.shellHook + ''
-            export PATH=$PWD/target/debug:$PATH
-          '';
-        };
-      }));
+    };
 }

--- a/shell.nix
+++ b/shell.nix
@@ -7,4 +7,4 @@
     }
   )
   { src = ./.; }
-).defaultNix
+).shellNix


### PR DESCRIPTION
Switched the nix expression used for building ante to use [flake-parts](https://github.com/hercules-ci/flake-parts) and [nci](https://github.com/yusdacra/nix-cargo-integration) instead of manually calling `buildRustPackage`. It should lower the amount of maintenance required for it, since the dependency hashes won't need to be updated each time `Cargo.lock` changes like it did recently as those are not required by `nci` at all. The `flake.nix` is also much simpler now thanks to `flake-parts`.