### PR TITLE
Clippy suggestions and cargo fmt

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,4 @@
-fn_args_layout = "Compressed"
+fn_params_layout = "Compressed"
 match_block_trailing_comma = true
 newline_style = "Unix"
 use_field_init_shorthand = true

--- a/src/cache/dependency_graph.rs
+++ b/src/cache/dependency_graph.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 
-use crate::cache::DefinitionInfoId;
-use petgraph::dot::{ Dot, Config };
-use petgraph::graph::{ DiGraph, NodeIndex };
 use super::ModuleCache;
+use crate::cache::DefinitionInfoId;
+use petgraph::dot::{Config, Dot};
+use petgraph::graph::{DiGraph, NodeIndex};
 
 #[derive(Default, Debug)]
 pub struct DependencyGraph {
@@ -31,12 +31,12 @@ impl DependencyGraph {
         println!("{dot:?}");
     }
 
-    pub fn set_definition<'c>(&mut self, definition: DefinitionInfoId) {
+    pub fn set_definition(&mut self, definition: DefinitionInfoId) {
         self.current_definition = Some(definition);
     }
 
     // add an edge when a global is referenced
-    pub fn add_edge<'c>(&mut self, dependency: DefinitionInfoId) {
+    pub fn add_edge(&mut self, dependency: DefinitionInfoId) {
         if let Some(dependent) = self.current_definition {
             let dependent = self.get_or_add_node(dependent);
             let dependency = self.get_or_add_node(dependency);

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -29,8 +29,8 @@ use std::path::{Path, PathBuf};
 use self::dependency_graph::DependencyGraph;
 
 mod counter;
-mod unsafecache;
 mod dependency_graph;
+mod unsafecache;
 
 /// The ModuleCache is for information needed until compilation is completely finished
 /// (ie. not just for one phase). Accessing each `Vec` inside the `ModuleCache` is done

--- a/src/cranelift_backend/mod.rs
+++ b/src/cranelift_backend/mod.rs
@@ -35,7 +35,7 @@ pub trait CodeGen {
     }
 }
 
-impl<'c> CodeGen for Ast {
+impl CodeGen for Ast {
     fn codegen<'a>(&'a self, context: &mut Context<'a>, builder: &mut FunctionBuilder) -> Value {
         dispatch_on_hir!(self, CodeGen::codegen, context, builder)
     }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -94,7 +94,7 @@ impl<'a> Ord for ErrorMessage<'a> {
 
 impl<'a> PartialOrd for ErrorMessage<'a> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.location.partial_cmp(&other.location)
+        Some(self.cmp(other))
     }
 }
 

--- a/src/hir/decision_tree_monomorphisation.rs
+++ b/src/hir/decision_tree_monomorphisation.rs
@@ -7,7 +7,10 @@ use crate::{
     util::fmap,
 };
 
-use super::{monomorphisation::{Context, Definition}, Variable};
+use super::{
+    monomorphisation::{Context, Definition},
+    Variable,
+};
 use crate::hir;
 
 impl<'c> Context<'c> {
@@ -196,7 +199,11 @@ impl<'c> Context<'c> {
 
                         hir::Definition {
                             variable: field_variable_id,
-                            expr: Box::new(Self::extract(variant_variable.clone().into(), field_index, monomorphized_field_type.unwrap())),
+                            expr: Box::new(Self::extract(
+                                variant_variable.clone().into(),
+                                field_index,
+                                monomorphized_field_type.unwrap(),
+                            )),
                             name: None,
                         }
                     })

--- a/src/hir/definitions.rs
+++ b/src/hir/definitions.rs
@@ -106,7 +106,7 @@ fn definition_type_eq(a: &types::Type, b: &types::Type) -> bool {
                 return false;
             }
             args1.iter().zip(args2).all(|(p1, p2)| definition_type_eq(p1, p2))
-                && definition_type_eq(&constructor1, &constructor2)
+                && definition_type_eq(constructor1, constructor2)
         },
         (Type::Struct(field_names1, _), Type::Struct(field_names2, _)) => {
             if field_names1.len() != field_names2.len() {

--- a/src/llvm/builtin.rs
+++ b/src/llvm/builtin.rs
@@ -172,13 +172,15 @@ fn deref_ptr<'g>(ptr: &Ast, typ: &Type, generator: &mut Generator<'g>) -> BasicV
 
     let ptr = ptr.codegen(generator).into_pointer_value();
     let ptr = generator.builder.build_pointer_cast(ptr, ret, "bitcast").unwrap();
-    generator.builder.build_load(element_type, ptr, "deref").unwrap().into()
+    generator.builder.build_load(element_type, ptr, "deref").unwrap()
 }
 
 /// offset (p: Ptr t) (offset: usz) = (p as usize + offset * size_of t) as Ptr t
 ///
 // This builtin is unnecessary once we replace it with size_of
-fn offset<'g>(ptr: &Ast, offset: IntValue<'g>, element_type: &Type, generator: &mut Generator<'g>) -> BasicValueEnum<'g> {
+fn offset<'g>(
+    ptr: &Ast, offset: IntValue<'g>, element_type: &Type, generator: &mut Generator<'g>,
+) -> BasicValueEnum<'g> {
     let ptr = ptr.codegen(generator).into_pointer_value();
     let element_type = generator.convert_type(element_type);
     unsafe { generator.builder.build_gep(element_type, ptr, &[offset], "offset").unwrap().into() }
@@ -260,8 +262,7 @@ fn truncate<'g>(x: IntValue<'g>, typ: &Type, generator: &mut Generator<'g>) -> B
 fn stack_alloc<'g>(x: &Ast, generator: &mut Generator<'g>) -> BasicValueEnum<'g> {
     let value = x.codegen(generator);
     let alloca = generator.builder.build_alloca(value.get_type(), "alloca").unwrap();
-    generator.builder.build_store(alloca, value)
-        .expect("Could not build store in stack_alloc");
+    generator.builder.build_store(alloca, value).expect("Could not build store in stack_alloc");
 
     let ptr_type = &crate::hir::Type::Primitive(PrimitiveType::Pointer);
     let opaque_ptr_type = generator.convert_type(ptr_type).into_pointer_type();

--- a/src/llvm/decisiontree.rs
+++ b/src/llvm/decisiontree.rs
@@ -30,8 +30,7 @@ impl<'g> Generator<'g> {
             .collect::<Vec<_>>();
 
         self.builder.position_at_end(end_block);
-        let phi = self.builder.build_phi(typ.unwrap(), "match_result")
-            .expect("Could not build phi");
+        let phi = self.builder.build_phi(typ.unwrap(), "match_result").expect("Could not build phi");
 
         // Inkwell forces us to pass a &[(&dyn BasicValue, _)] which prevents us from
         // passing an entire Vec since we'd also need to store the basic values in another
@@ -49,7 +48,8 @@ impl<'g> Generator<'g> {
     fn codegen_subtree(&mut self, tree: &hir::DecisionTree, branches: &[BasicBlock<'g>]) {
         match tree {
             hir::DecisionTree::Leaf(n) => {
-                self.builder.build_unconditional_branch(branches[*n])
+                self.builder
+                    .build_unconditional_branch(branches[*n])
                     .expect("Could not create br during codegen_subtree");
             },
             hir::DecisionTree::Definition(definition, subtree) => {
@@ -80,13 +80,11 @@ impl<'g> Generator<'g> {
         if let Some(subtree) = else_case {
             self.codegen_subtree(subtree, branches);
         } else {
-            self.builder.build_unreachable()
-                .expect("Could not create unreachable during build_switch");
+            self.builder.build_unreachable().expect("Could not create unreachable during build_switch");
         }
 
         self.builder.position_at_end(starting_block);
         let tag = int_to_switch_on.into_int_value();
-        self.builder.build_switch(tag, else_block, &cases)
-            .expect("Could not build switch");
+        self.builder.build_switch(tag, else_block, &cases).expect("Could not build switch");
     }
 }

--- a/src/nameresolution/builtin.rs
+++ b/src/nameresolution/builtin.rs
@@ -66,7 +66,7 @@ pub fn prelude_path() -> PathBuf {
     crate::util::stdlib_dir().join("prelude.an")
 }
 
-pub fn import_prelude<'a>(resolver: &mut NameResolver, cache: &mut ModuleCache<'a>) {
+pub fn import_prelude(resolver: &mut NameResolver, cache: &mut ModuleCache<'_>) {
     if resolver.filepath == prelude_path() {
         // If we're in the prelude include the built-in symbol "builtin" to define primitives
         resolver.current_scope().definitions.insert("builtin".into(), BUILTIN_ID);

--- a/src/nameresolution/mod.rs
+++ b/src/nameresolution/mod.rs
@@ -161,7 +161,7 @@ impl PartialEq for NameResolver {
 
 macro_rules! lookup_fn {
     ( $name:ident , $stack_field:ident , $cache_field:ident, $return_type:ty ) => {
-        fn $name<'c>(&self, name: &str, cache: &mut ModuleCache<'c>) -> Option<$return_type> {
+        fn $name(&self, name: &str, cache: &mut ModuleCache<'_>) -> Option<$return_type> {
             let function_scope = self.scopes.last().unwrap();
             for stack in function_scope.iter().rev() {
                 if let Some(id) = stack.$stack_field.get(name) {
@@ -351,16 +351,14 @@ impl NameResolver {
         self.push_existing_type_variable(key, id, location)
     }
 
-    fn pop_scope<'c>(
-        &mut self, cache: &mut ModuleCache<'c>, warn_unused: bool, id_to_ignore: Option<DefinitionInfoId>,
-    ) {
+    fn pop_scope(&mut self, cache: &mut ModuleCache<'_>, warn_unused: bool, id_to_ignore: Option<DefinitionInfoId>) {
         if warn_unused {
             self.current_scope().check_for_unused_definitions(cache, id_to_ignore);
         }
         self.function_scopes().pop();
     }
 
-    fn pop_lambda<'c>(&mut self, cache: &mut ModuleCache<'c>) {
+    fn pop_lambda(&mut self, cache: &mut ModuleCache<'_>) {
         let function = self.function_scopes();
         let function_id = function.function_id;
         assert_eq!(function.scopes.len(), 1);
@@ -413,7 +411,7 @@ impl NameResolver {
 
     /// Add a DefinitionInfoId to a trait's list of required definitions and add
     /// the trait to the DefinitionInfo's list of required traits.
-    fn attach_to_trait<'c>(&mut self, id: DefinitionInfoId, trait_id: TraitInfoId, cache: &mut ModuleCache<'c>) {
+    fn attach_to_trait(&mut self, id: DefinitionInfoId, trait_id: TraitInfoId, cache: &mut ModuleCache<'_>) {
         let trait_info = &mut cache.trait_infos[trait_id.0];
         trait_info.definitions.push(id);
 

--- a/src/nameresolution/scope.rs
+++ b/src/nameresolution/scope.rs
@@ -171,7 +171,7 @@ impl TypeVariableScope {
     /// Returns None if a type variable with the same name is already in scope.
     pub fn push_existing_type_variable(&mut self, key: String, id: TypeVariableId) -> Option<TypeVariableId> {
         let prev = self.type_variables.insert(key, id);
-        if !prev.is_none() {
+        if prev.is_some() {
             return None;
         }
         Some(id)
@@ -219,7 +219,7 @@ impl FunctionScopes {
         self.scopes.pop();
     }
 
-    pub fn push_new_scope<'c>(&mut self, cache: &mut ModuleCache<'c>) {
+    pub fn push_new_scope(&mut self, cache: &mut ModuleCache<'_>) {
         self.scopes.push(Scope::new(cache));
     }
 

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -35,7 +35,7 @@ type AstResult<'a, 'b> = ParseResult<'a, 'b, Ast<'b>>;
 
 /// The entry point to parsing. Parses an entire file, printing any
 /// error found, or returns the Ast if there was no error.
-pub fn parse<'a, 'b>(input: Input<'a, 'b>) -> Result<Ast<'b>, ParseError<'b>> {
+pub fn parse<'b>(input: Input<'_, 'b>) -> Result<Ast<'b>, ParseError<'b>> {
     let result = parse_file(input);
     if let Err(error) = &result {
         eprintln!("{}", error);
@@ -44,7 +44,7 @@ pub fn parse<'a, 'b>(input: Input<'a, 'b>) -> Result<Ast<'b>, ParseError<'b>> {
 }
 
 /// A file is a sequence of statements, separated by newlines.
-pub fn parse_file<'a, 'b>(input: Input<'a, 'b>) -> Result<Ast<'b>, ParseError<'b>> {
+pub fn parse_file<'b>(input: Input<'_, 'b>) -> Result<Ast<'b>, ParseError<'b>> {
     let (input, _, _) = maybe_newline(input)?;
     let (input, ast, _) = statement_list(input)?;
     let (input, _, _) = maybe_newline(input)?;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -171,7 +171,7 @@ impl Type {
         self == &Type::Primitive(PrimitiveType::FloatType)
     }
 
-    pub fn is_unit<'c>(&self, cache: &ModuleCache<'c>) -> bool {
+    pub fn is_unit(&self, cache: &ModuleCache<'_>) -> bool {
         match self {
             Type::Primitive(PrimitiveType::UnitType) => true,
             Type::TypeVariable(id) => match &cache.type_bindings[id.0] {
@@ -182,14 +182,12 @@ impl Type {
         }
     }
 
-    pub fn is_union_constructor<'a, 'c>(&'a self, cache: &'a ModuleCache<'c>) -> bool {
+    pub fn is_union_constructor<'a>(&'a self, cache: &'a ModuleCache<'_>) -> bool {
         self.union_constructor_variants(cache).is_some()
     }
 
     /// Returns Some(variants) if this is a union type constructor or union type itself.
-    pub fn union_constructor_variants<'a, 'c>(
-        &'a self, cache: &'a ModuleCache<'c>,
-    ) -> Option<&'a Vec<TypeConstructor>> {
+    pub fn union_constructor_variants<'a>(&'a self, cache: &'a ModuleCache<'_>) -> Option<&'a Vec<TypeConstructor>> {
         use Type::*;
         match self {
             Primitive(_) => None,
@@ -258,7 +256,7 @@ impl Type {
                 if let TypeBinding::Bound(binding) = &cache.type_bindings[id.0] {
                     return binding.traverse_rec(cache, f);
                 }
-                for (_, typ) in fields {
+                for typ in fields.values() {
                     typ.traverse_rec(cache, f);
                 }
             },
@@ -299,7 +297,7 @@ impl Type {
                 }
             },
             Type::Struct(fields, _) => {
-                for (_, typ) in fields {
+                for typ in fields.values() {
                     typ.traverse_no_follow_rec(f);
                 }
             },
@@ -375,7 +373,7 @@ impl GeneralizedType {
         }
     }
 
-    pub fn is_union_constructor<'a, 'c>(&'a self, cache: &'a ModuleCache<'c>) -> bool {
+    pub fn is_union_constructor<'a>(&'a self, cache: &'a ModuleCache<'_>) -> bool {
         self.remove_forall().is_union_constructor(cache)
     }
 

--- a/src/types/pattern.rs
+++ b/src/types/pattern.rs
@@ -322,7 +322,7 @@ fn get_covered_constructors<T>(variants: &BTreeMap<&VariantTag, T>) -> BTreeSet<
 
 /// Given a hashmap from variant tag -> arity,
 /// return true if the hashmap covers all constructors for its type.
-fn get_missing_cases<'c, T>(variants: &BTreeMap<&VariantTag, T>, cache: &ModuleCache<'c>) -> BTreeSet<VariantTag> {
+fn get_missing_cases<T>(variants: &BTreeMap<&VariantTag, T>, cache: &ModuleCache<'_>) -> BTreeSet<VariantTag> {
     use VariantTag::*;
 
     if let Some(result) = get_missing_builtin_cases(variants) {
@@ -773,14 +773,14 @@ struct DebugConstructor {
 }
 
 impl DebugConstructor {
-    fn new<'c>(tag: &Option<VariantTag>, cache: &ModuleCache<'c>) -> DebugConstructor {
+    fn new(tag: &Option<VariantTag>, cache: &ModuleCache<'_>) -> DebugConstructor {
         use VariantTag::*;
         let tag = match &tag {
             Some(UserDefined(id)) => cache.definition_infos[id.0].name.clone(),
             Some(Literal(LiteralKind::Integer(_, Some(kind)))) => format!("_ : {}", kind),
-            Some(Literal(LiteralKind::Integer(_, None))) => format!("_ : Int"),
+            Some(Literal(LiteralKind::Integer(_, None))) => "_ : Int".to_string(),
             Some(Literal(LiteralKind::Float(_, Some(kind)))) => format!("_ : {}", kind),
-            Some(Literal(LiteralKind::Float(_, None))) => format!("_ : Float"),
+            Some(Literal(LiteralKind::Float(_, None))) => "_ : Float".to_string(),
             Some(Literal(LiteralKind::String(_))) => "_ : string".to_string(),
             Some(Literal(LiteralKind::Char(_))) => "_ : char".to_string(),
 
@@ -798,7 +798,7 @@ impl DebugConstructor {
         DebugConstructor { tag, fields: vec![] }
     }
 
-    fn from_case<'c>(case: &Case, cache: &ModuleCache<'c>) -> DebugConstructor {
+    fn from_case(case: &Case, cache: &ModuleCache<'_>) -> DebugConstructor {
         let mut constructor = DebugConstructor::new(&case.tag, cache);
         constructor.fields = case.fields.clone();
         constructor
@@ -888,8 +888,8 @@ fn set_type<'c>(id: DefinitionInfoId, expected: &Type, location: Location<'c>, c
 /// Since this is only useful for type inference of arguments, if the constructor is
 /// not a function type like (Some : a -> Maybe a) (and thus has no arguments like None : Maybe a)
 /// then we can skip this step completely.
-fn unify_constructor_type<'c, 'a>(
-    constructor: &'a Type, expected: &Type, location: Location<'c>, cache: &mut ModuleCache<'c>,
+fn unify_constructor_type<'c>(
+    constructor: &Type, expected: &Type, location: Location<'c>, cache: &mut ModuleCache<'c>,
 ) {
     // If it is not a function, there are no arguments, so there's no need to unify the type with
     // the expected type. We could unify to assert they're equal but this would incur a runtime cost.
@@ -914,7 +914,7 @@ fn parameters_of_type(typ: &Type) -> Vec<&Type> {
 }
 
 impl Case {
-    fn get_constructor_type<'c>(&self, expected_type: &Type, cache: &mut ModuleCache<'c>) -> Type {
+    fn get_constructor_type(&self, expected_type: &Type, cache: &mut ModuleCache<'_>) -> Type {
         use VariantTag::*;
         match &self.tag {
             Some(UserDefined(id)) => {

--- a/src/types/traitchecker.rs
+++ b/src/types/traitchecker.rs
@@ -46,8 +46,8 @@ const DEFAULT_FLOAT_TYPE: Type = Type::Primitive(PrimitiveType::FloatTag(FloatKi
 /// Returns the list of traits propogated upward.
 /// Binds the impls that were searched for and found to the required_impls
 /// in the callsite VariableInfo, and errors for any impls that couldn't be found.
-pub fn resolve_traits<'a>(
-    constraints: TraitConstraints, typevars_in_fn_signature: &[TypeVariableId], cache: &mut ModuleCache<'a>,
+pub fn resolve_traits(
+    constraints: TraitConstraints, typevars_in_fn_signature: &[TypeVariableId], cache: &mut ModuleCache<'_>,
 ) -> Vec<RequiredTrait> {
     let (propagated_traits, other_constraints) = sort_traits(constraints, typevars_in_fn_signature, cache);
 
@@ -142,8 +142,8 @@ type PropagatedTraits = Vec<RequiredTrait>;
 /// - All other constraints. This includes all other normal trait constraints like `Print a`
 ///   or `Cast a b` which should have an impl searched for now. Traits like this that shouldn't
 ///   have an impl searched for belong to the first category of propogated traits.
-fn sort_traits<'c>(
-    constraints: TraitConstraints, typevars_in_fn_signature: &[TypeVariableId], cache: &ModuleCache<'c>,
+fn sort_traits(
+    constraints: TraitConstraints, typevars_in_fn_signature: &[TypeVariableId], cache: &ModuleCache<'_>,
 ) -> (PropagatedTraits, TraitConstraints) {
     let mut propogated_traits = vec![];
     let mut other_constraints = Vec::with_capacity(constraints.len());
@@ -165,8 +165,8 @@ fn sort_traits<'c>(
 /// For example, the trait constraint `Print i32` should never be propogated because it doesn't
 /// contain any typevariables. A constraint like `Print a` may be propogated if `a` is a
 /// typevariable used in the signature of the current function.
-fn should_propagate<'a>(
-    constraint: &TraitConstraint, typevars_in_fn_signature: &[TypeVariableId], cache: &ModuleCache<'a>,
+fn should_propagate(
+    constraint: &TraitConstraint, typevars_in_fn_signature: &[TypeVariableId], cache: &ModuleCache<'_>,
 ) -> bool {
     // Don't check the fundeps since only the typeargs proper are used to find impls
     let arg_count = cache[constraint.trait_id()].typeargs.len();
@@ -180,8 +180,8 @@ fn should_propagate<'a>(
 
 /// Try to solve a normal constraint, but avoid issuing an error if it fails.
 /// Returns Some(constraint) on error.
-fn try_solve_normal_constraint<'a, 'c>(
-    constraint: &'a TraitConstraint, bindings: UnificationBindings, cache: &mut ModuleCache<'c>,
+fn try_solve_normal_constraint<'a>(
+    constraint: &'a TraitConstraint, bindings: UnificationBindings, cache: &mut ModuleCache<'_>,
 ) -> Option<&'a TraitConstraint> {
     let mut matching_impls = find_matching_impls(constraint, &bindings, RECURSION_LIMIT, cache);
 
@@ -199,7 +199,7 @@ fn try_solve_normal_constraint<'a, 'c>(
 
 /// Search and bind a specific impl to the given TraitConstraint, erroring if 0
 /// or >1 matching impls are found.
-fn solve_normal_constraint<'c>(constraint: &TraitConstraint, cache: &mut ModuleCache<'c>) {
+fn solve_normal_constraint(constraint: &TraitConstraint, cache: &mut ModuleCache<'_>) {
     let bindings = UnificationBindings::empty();
     let mut matching_impls = find_matching_impls(constraint, &bindings, RECURSION_LIMIT, cache);
 
@@ -249,8 +249,8 @@ fn solve_normal_constraint<'c>(constraint: &TraitConstraint, cache: &mut ModuleC
 ///
 /// Note that any impls that are automatically impld by the compiler will not have their
 /// ImplInfoIds within the returned Vec (since they don't have any).
-fn find_matching_impls<'c>(
-    constraint: &TraitConstraint, bindings: &UnificationBindings, fuel: u32, cache: &mut ModuleCache<'c>,
+fn find_matching_impls(
+    constraint: &TraitConstraint, bindings: &UnificationBindings, fuel: u32, cache: &mut ModuleCache<'_>,
 ) -> Vec<(Vec<(ImplInfoId, TraitConstraint)>, UnificationBindings)> {
     if fuel == 0 {
         if !RECURSION_WARNING_PRINTED.swap(true, std::sync::atomic::Ordering::Relaxed) {
@@ -268,8 +268,8 @@ fn find_matching_impls<'c>(
 /// required `given` constraints, these impls in the given constraints are also returned.
 /// Thus, each element of the returned Vec will contain a set of the original impl found
 /// and all impls it depends on (in practice this number is small, usually < 2).
-fn find_matching_normal_impls<'c>(
-    constraint: &TraitConstraint, bindings: &UnificationBindings, fuel: u32, cache: &mut ModuleCache<'c>,
+fn find_matching_normal_impls(
+    constraint: &TraitConstraint, bindings: &UnificationBindings, fuel: u32, cache: &mut ModuleCache<'_>,
 ) -> Vec<(Vec<(ImplInfoId, TraitConstraint)>, UnificationBindings)> {
     let scope = cache[constraint.scope].clone();
 
@@ -308,9 +308,9 @@ fn find_matching_normal_impls<'c>(
 /// `Cast a string` and is thus only valid if that impl can be found as well.
 /// If any of these given constraints cannot be solved then None is returned. Otherwise, the Vec
 /// of the original constraint and all its required given constraints are returned.
-fn check_given_constraints<'c>(
+fn check_given_constraints(
     constraint: &TraitConstraint, impl_id: ImplInfoId, mut unification_bindings: UnificationBindings,
-    mut impl_bindings: TypeBindings, fuel: u32, cache: &mut ModuleCache<'c>,
+    mut impl_bindings: TypeBindings, fuel: u32, cache: &mut ModuleCache<'_>,
 ) -> Option<(Vec<(ImplInfoId, TraitConstraint)>, UnificationBindings)> {
     let mut required_impls = vec![(impl_id, constraint.clone())];
 

--- a/src/types/traits.rs
+++ b/src/types/traits.rs
@@ -124,7 +124,7 @@ impl RequiredTrait {
         TraitConstraint { required, scope }
     }
 
-    pub fn find_all_typevars<'b>(&self, cache: &ModuleCache<'b>) -> Vec<TypeVariableId> {
+    pub fn find_all_typevars(&self, cache: &ModuleCache<'_>) -> Vec<TypeVariableId> {
         self.signature.find_all_typevars(cache)
     }
 
@@ -139,7 +139,7 @@ impl RequiredTrait {
 }
 
 impl ConstraintSignature {
-    pub fn find_all_typevars<'b>(&self, cache: &ModuleCache<'b>) -> Vec<TypeVariableId> {
+    pub fn find_all_typevars(&self, cache: &ModuleCache<'_>) -> Vec<TypeVariableId> {
         let mut typevars = vec![];
         for typ in &self.args {
             typevars.append(&mut find_all_typevars(typ, false, cache));

--- a/src/types/typeprinter.rs
+++ b/src/types/typeprinter.rs
@@ -60,9 +60,9 @@ fn fill_typevar_map(map: &mut HashMap<TypeVariableId, String>, typevars: Vec<Typ
 /// `TypeVariableId(55)` that may be used in both the type and any traits are given the same
 /// name in both. Printing out the type separately from the traits would cause type variable
 /// naming to restart at `a` which may otherwise give them different names.
-pub fn show_type_and_traits<'b>(
+pub fn show_type_and_traits(
     typ: &GeneralizedType, traits: &[RequiredTrait], trait_info: &Option<(TraitInfoId, Vec<Type>)>,
-    cache: &ModuleCache<'b>,
+    cache: &ModuleCache<'_>,
 ) -> (String, Vec<String>) {
     let mut map = HashMap::new();
     let mut current = 'a';

--- a/src/util/trustme.rs
+++ b/src/util/trustme.rs
@@ -7,10 +7,11 @@
 //! to be removed if the AST nodes ever become arena allocated and
 //! a key can be used from the arena instead of a direct reference in the ModuleCache.
 
-pub fn extend_lifetime<'a, 'b, T>(x: &'a mut T) -> &'b mut T {
+pub fn extend_lifetime<'b, T>(x: &mut T) -> &'b mut T {
     unsafe { std::mem::transmute(x) }
 }
 
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn make_mut<'a, T>(x: *const T) -> &'a mut T {
     #[allow(clippy::transmute_ptr_to_ref)]
     unsafe {
@@ -18,7 +19,7 @@ pub fn make_mut<'a, T>(x: *const T) -> &'a mut T {
     }
 }
 
-pub fn make_mut_ref<'a, 'b, T>(x: &'a T) -> &'b mut T {
+pub fn make_mut_ref<'b, T>(x: &T) -> &'b mut T {
     #[allow(mutable_transmutes)]
     unsafe {
         std::mem::transmute(x)


### PR DESCRIPTION
Mostly clippy suggestions about lifetime elision, but 2 strict `clippy` errors fixed as well. The 2 `clippy` errors made working on the codebase inconvenient for me, as `rust-analyzer` would not report any `rustc` errors after getting an error from `clippy`.

<details>
<summary>Clippy errors before this PR</summary>

```rust
warning: the following explicit lifetimes could be elided: 'a
  --> src/parser/mod.rs:38:14
   |
38 | pub fn parse<'a, 'b>(input: Input<'a, 'b>) -> Result<Ast<'b>, ParseError<'b>> {
   |              ^^                   ^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
   = note: `#[warn(clippy::needless_lifetimes)]` on by default
help: elide the lifetimes
   |
38 - pub fn parse<'a, 'b>(input: Input<'a, 'b>) -> Result<Ast<'b>, ParseError<'b>> {
38 + pub fn parse<'b>(input: Input<'_, 'b>) -> Result<Ast<'b>, ParseError<'b>> {
   |

warning: the following explicit lifetimes could be elided: 'a
  --> src/parser/mod.rs:47:19
   |
47 | pub fn parse_file<'a, 'b>(input: Input<'a, 'b>) -> Result<Ast<'b>, ParseError<'b>> {
   |                   ^^                   ^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
   |
47 - pub fn parse_file<'a, 'b>(input: Input<'a, 'b>) -> Result<Ast<'b>, ParseError<'b>> {
47 + pub fn parse_file<'b>(input: Input<'_, 'b>) -> Result<Ast<'b>, ParseError<'b>> {
   |

warning: the following explicit lifetimes could be elided: 'a
  --> src/util/trustme.rs:10:24
   |
10 | pub fn extend_lifetime<'a, 'b, T>(x: &'a mut T) -> &'b mut T {
   |                        ^^             ^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
   |
10 - pub fn extend_lifetime<'a, 'b, T>(x: &'a mut T) -> &'b mut T {
10 + pub fn extend_lifetime<'b, T>(x: &mut T) -> &'b mut T {
   |

error: this public function might dereference a raw pointer but is not marked `unsafe`
  --> src/util/trustme.rs:17:29
   |
17 |         std::mem::transmute(x)
   |                             ^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#not_unsafe_ptr_arg_deref
   = note: `#[deny(clippy::not_unsafe_ptr_arg_deref)]` on by default

warning: the following explicit lifetimes could be elided: 'a
  --> src/util/trustme.rs:21:21
   |
21 | pub fn make_mut_ref<'a, 'b, T>(x: &'a T) -> &'b mut T {
   |                     ^^             ^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
   |
21 - pub fn make_mut_ref<'a, 'b, T>(x: &'a T) -> &'b mut T {
21 + pub fn make_mut_ref<'b, T>(x: &T) -> &'b mut T {
   |

error: incorrect implementation of `partial_cmp` on an `Ord` type
  --> src/error/mod.rs:95:1
   |
95 | /  impl<'a> PartialOrd for ErrorMessage<'a> {
96 | |      fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
   | | _______________________________________________________________________-
97 | ||         self.location.partial_cmp(&other.location)
98 | ||     }
   | ||_____- help: change this to: `{ Some(self.cmp(other)) }`
99 | |  }
   | |__^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#incorrect_partial_ord_impl_on_ord_type
   = note: `#[deny(clippy::incorrect_partial_ord_impl_on_ord_type)]` on by default

warning: this lifetime isn't used in the function definition
  --> src/cache/dependency_graph.rs:34:27
   |
34 |     pub fn set_definition<'c>(&mut self, definition: DefinitionInfoId) {
   |                           ^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#extra_unused_lifetimes
   = note: `#[warn(clippy::extra_unused_lifetimes)]` on by default

warning: this lifetime isn't used in the function definition
  --> src/cache/dependency_graph.rs:39:21
   |
39 |     pub fn add_edge<'c>(&mut self, dependency: DefinitionInfoId) {
   |                     ^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#extra_unused_lifetimes

warning: this expression creates a reference which is immediately dereferenced by the compiler
   --> src/hir/definitions.rs:109:39
    |
109 |                 && definition_type_eq(&constructor1, &constructor2)
    |                                       ^^^^^^^^^^^^^ help: change this to: `constructor1`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
    = note: `#[warn(clippy::needless_borrow)]` on by default

warning: this expression creates a reference which is immediately dereferenced by the compiler
   --> src/hir/definitions.rs:109:54
    |
109 |                 && definition_type_eq(&constructor1, &constructor2)
    |                                                      ^^^^^^^^^^^^^ help: change this to: `constructor2`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: this expression creates a reference which is immediately dereferenced by the compiler
    --> src/hir/monomorphisation.rs:1525:61
     |
1525 |                     typ => self.get_field_index(field_name, &typ),
     |                                                             ^^^^ help: change this to: `typ`
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: use of `expect` followed by a function call
    --> src/hir/monomorphisation.rs:1531:91
     |
1531 |               Struct(fields, _binding) => fields.keys().position(|name| name == field_name).expect(&format!(
     |  ___________________________________________________________________________________________^
1532 | |                 "Expected type {} to have a field named '{}'",
1533 | |                 typ.display(&self.cache),
1534 | |                 field_name
1535 | |             )) as u32,
     | |______________^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#expect_fun_call
     = note: `#[warn(clippy::expect_fun_call)]` on by default
help: try
     |
1531 ~             Struct(fields, _binding) => fields.keys().position(|name| name == field_name).unwrap_or_else(|| panic!("Expected type {} to have a field named '{}'",
1532 +                 typ.display(&self.cache),
1533 ~                 field_name)) as u32,
     |

warning: the following explicit lifetimes could be elided: 'a
  --> src/nameresolution/builtin.rs:69:23
   |
69 | pub fn import_prelude<'a>(resolver: &mut NameResolver, cache: &mut ModuleCache<'a>) {
   |                       ^^                                                       ^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
   |
69 - pub fn import_prelude<'a>(resolver: &mut NameResolver, cache: &mut ModuleCache<'a>) {
69 + pub fn import_prelude(resolver: &mut NameResolver, cache: &mut ModuleCache<'_>) {
   |

warning: this boolean expression can be simplified
   --> src/nameresolution/scope.rs:174:12
    |
174 |         if !prev.is_none() {
    |            ^^^^^^^^^^^^^^^ help: try: `prev.is_some()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#nonminimal_bool
    = note: `#[warn(clippy::nonminimal_bool)]` on by default

warning: the following explicit lifetimes could be elided: 'c
   --> src/nameresolution/scope.rs:222:27
    |
222 |     pub fn push_new_scope<'c>(&mut self, cache: &mut ModuleCache<'c>) {
    |                           ^^                                     ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
222 -     pub fn push_new_scope<'c>(&mut self, cache: &mut ModuleCache<'c>) {
222 +     pub fn push_new_scope(&mut self, cache: &mut ModuleCache<'_>) {
    |

warning: the following explicit lifetimes could be elided: 'c
   --> src/nameresolution/mod.rs:164:18
    |
164 |         fn $name<'c>(&self, name: &str, cache: &mut ModuleCache<'c>) -> Option<$return_type> {
    |                  ^^                                             ^^
...
186 |     lookup_fn!(lookup_type, types, type_infos, TypeInfoId);
    |     ------------------------------------------------------
    |     |
    |     in this macro invocation
    |     in this macro invocation
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
    = note: this warning originates in the macro `lookup_fn` (in Nightly builds, run with -Z macro-backtrace for more info)
help: elide the lifetimes
    |
164 -         fn $name<'c>(&self, name: &str, cache: &mut ModuleCache<'c>) -> Option<$return_type> {
164 +         fn $name(&self, name: &str, cache: &mut ModuleCache<'_>) -> Option<$return_type> {
    |

warning: the following explicit lifetimes could be elided: 'c
   --> src/nameresolution/mod.rs:164:18
    |
164 |         fn $name<'c>(&self, name: &str, cache: &mut ModuleCache<'c>) -> Option<$return_type> {
    |                  ^^                                             ^^
...
187 |     lookup_fn!(lookup_trait, traits, trait_infos, TraitInfoId);
    |     ----------------------------------------------------------
    |     |
    |     in this macro invocation
    |     in this macro invocation
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
    = note: this warning originates in the macro `lookup_fn` (in Nightly builds, run with -Z macro-backtrace for more info)
help: elide the lifetimes
    |
164 -         fn $name<'c>(&self, name: &str, cache: &mut ModuleCache<'c>) -> Option<$return_type> {
164 +         fn $name(&self, name: &str, cache: &mut ModuleCache<'_>) -> Option<$return_type> {
    |

warning: the following explicit lifetimes could be elided: 'c
   --> src/nameresolution/mod.rs:354:18
    |
354 |     fn pop_scope<'c>(
    |                  ^^
355 |         &mut self, cache: &mut ModuleCache<'c>, warn_unused: bool, id_to_ignore: Option<DefinitionInfoId>,
    |                                            ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
354 ~     fn pop_scope(
355 ~         &mut self, cache: &mut ModuleCache<'_>, warn_unused: bool, id_to_ignore: Option<DefinitionInfoId>,
    |

warning: the following explicit lifetimes could be elided: 'c
   --> src/nameresolution/mod.rs:363:19
    |
363 |     fn pop_lambda<'c>(&mut self, cache: &mut ModuleCache<'c>) {
    |                   ^^                                     ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
363 -     fn pop_lambda<'c>(&mut self, cache: &mut ModuleCache<'c>) {
363 +     fn pop_lambda(&mut self, cache: &mut ModuleCache<'_>) {
    |

warning: the following explicit lifetimes could be elided: 'c
   --> src/nameresolution/mod.rs:416:24
    |
416 |     fn attach_to_trait<'c>(&mut self, id: DefinitionInfoId, trait_id: TraitInfoId, cache: &mut ModuleCache<'c>) {
    |                        ^^                                                                                  ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
416 -     fn attach_to_trait<'c>(&mut self, id: DefinitionInfoId, trait_id: TraitInfoId, cache: &mut ModuleCache<'c>) {
416 +     fn attach_to_trait(&mut self, id: DefinitionInfoId, trait_id: TraitInfoId, cache: &mut ModuleCache<'_>) {
    |

warning: this returns a `Result<_, ()>`
   --> src/nameresolution/mod.rs:629:5
    |
629 |     pub fn start(ast: Ast<'c>, cache: &mut ModuleCache<'c>) -> Result<(), ()> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: use a custom `Error` type instead
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#result_unit_err
    = note: `#[warn(clippy::result_unit_err)]` on by default

warning: the following explicit lifetimes could be elided: 'c
   --> src/types/pattern.rs:325:22
    |
325 | fn get_missing_cases<'c, T>(variants: &BTreeMap<&VariantTag, T>, cache: &ModuleCache<'c>) -> BTreeSet<VariantTag> {
    |                      ^^                                                              ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
325 - fn get_missing_cases<'c, T>(variants: &BTreeMap<&VariantTag, T>, cache: &ModuleCache<'c>) -> BTreeSet<VariantTag> {
325 + fn get_missing_cases<T>(variants: &BTreeMap<&VariantTag, T>, cache: &ModuleCache<'_>) -> BTreeSet<VariantTag> {
    |

warning: the following explicit lifetimes could be elided: 'c
   --> src/types/pattern.rs:776:12
    |
776 |     fn new<'c>(tag: &Option<VariantTag>, cache: &ModuleCache<'c>) -> DebugConstructor {
    |            ^^                                                ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
776 -     fn new<'c>(tag: &Option<VariantTag>, cache: &ModuleCache<'c>) -> DebugConstructor {
776 +     fn new(tag: &Option<VariantTag>, cache: &ModuleCache<'_>) -> DebugConstructor {
    |

warning: useless use of `format!`
   --> src/types/pattern.rs:781:61
    |
781 |             Some(Literal(LiteralKind::Integer(_, None))) => format!("_ : Int"),
    |                                                             ^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `"_ : Int".to_string()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_format
    = note: `#[warn(clippy::useless_format)]` on by default

warning: useless use of `format!`
   --> src/types/pattern.rs:783:59
    |
783 |             Some(Literal(LiteralKind::Float(_, None))) => format!("_ : Float"),
    |                                                           ^^^^^^^^^^^^^^^^^^^^ help: consider using `.to_string()`: `"_ : Float".to_string()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#useless_format

warning: the following explicit lifetimes could be elided: 'c
   --> src/types/pattern.rs:801:18
    |
801 |     fn from_case<'c>(case: &Case, cache: &ModuleCache<'c>) -> DebugConstructor {
    |                  ^^                                   ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
801 -     fn from_case<'c>(case: &Case, cache: &ModuleCache<'c>) -> DebugConstructor {
801 +     fn from_case(case: &Case, cache: &ModuleCache<'_>) -> DebugConstructor {
    |

warning: the following explicit lifetimes could be elided: 'a
   --> src/types/pattern.rs:891:31
    |
891 | fn unify_constructor_type<'c, 'a>(
    |                               ^^
892 |     constructor: &'a Type, expected: &Type, location: Location<'c>, cache: &mut ModuleCache<'c>,
    |                   ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
891 ~ fn unify_constructor_type<'c>(
892 ~     constructor: &Type, expected: &Type, location: Location<'c>, cache: &mut ModuleCache<'c>,
    |

warning: the following explicit lifetimes could be elided: 'c
   --> src/types/pattern.rs:917:29
    |
917 |     fn get_constructor_type<'c>(&self, expected_type: &Type, cache: &mut ModuleCache<'c>) -> Type {
    |                             ^^                                                       ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
917 -     fn get_constructor_type<'c>(&self, expected_type: &Type, cache: &mut ModuleCache<'c>) -> Type {
917 +     fn get_constructor_type(&self, expected_type: &Type, cache: &mut ModuleCache<'_>) -> Type {
    |

warning: the following explicit lifetimes could be elided: 'a
  --> src/types/traitchecker.rs:49:23
   |
49 | pub fn resolve_traits<'a>(
   |                       ^^
50 |     constraints: TraitConstraints, typevars_in_fn_signature: &[TypeVariableId], cache: &mut ModuleCache<'a>,
   |                                                                                                         ^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
   |
49 ~ pub fn resolve_traits(
50 ~     constraints: TraitConstraints, typevars_in_fn_signature: &[TypeVariableId], cache: &mut ModuleCache<'_>,
   |

warning: the following explicit lifetimes could be elided: 'c
   --> src/types/traitchecker.rs:145:16
    |
145 | fn sort_traits<'c>(
    |                ^^
146 |     constraints: TraitConstraints, typevars_in_fn_signature: &[TypeVariableId], cache: &ModuleCache<'c>,
    |                                                                                                     ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
145 ~ fn sort_traits(
146 ~     constraints: TraitConstraints, typevars_in_fn_signature: &[TypeVariableId], cache: &ModuleCache<'_>,
    |

warning: the following explicit lifetimes could be elided: 'a
   --> src/types/traitchecker.rs:168:21
    |
168 | fn should_propagate<'a>(
    |                     ^^
169 |     constraint: &TraitConstraint, typevars_in_fn_signature: &[TypeVariableId], cache: &ModuleCache<'a>,
    |                                                                                                    ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
168 ~ fn should_propagate(
169 ~     constraint: &TraitConstraint, typevars_in_fn_signature: &[TypeVariableId], cache: &ModuleCache<'_>,
    |

warning: the following explicit lifetimes could be elided: 'c
   --> src/types/traitchecker.rs:183:36
    |
183 | fn try_solve_normal_constraint<'a, 'c>(
    |                                    ^^
184 |     constraint: &'a TraitConstraint, bindings: UnificationBindings, cache: &mut ModuleCache<'c>,
    |                                                                                             ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
183 ~ fn try_solve_normal_constraint<'a>(
184 ~     constraint: &'a TraitConstraint, bindings: UnificationBindings, cache: &mut ModuleCache<'_>,
    |

warning: the following explicit lifetimes could be elided: 'c
   --> src/types/traitchecker.rs:202:28
    |
202 | fn solve_normal_constraint<'c>(constraint: &TraitConstraint, cache: &mut ModuleCache<'c>) {
    |                            ^^                                                        ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
202 - fn solve_normal_constraint<'c>(constraint: &TraitConstraint, cache: &mut ModuleCache<'c>) {
202 + fn solve_normal_constraint(constraint: &TraitConstraint, cache: &mut ModuleCache<'_>) {
    |

warning: the following explicit lifetimes could be elided: 'c
   --> src/types/traitchecker.rs:252:24
    |
252 | fn find_matching_impls<'c>(
    |                        ^^
253 |     constraint: &TraitConstraint, bindings: &UnificationBindings, fuel: u32, cache: &mut ModuleCache<'c>,
    |                                                                                                      ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
252 ~ fn find_matching_impls(
253 ~     constraint: &TraitConstraint, bindings: &UnificationBindings, fuel: u32, cache: &mut ModuleCache<'_>,
    |

warning: the following explicit lifetimes could be elided: 'c
   --> src/types/traitchecker.rs:271:31
    |
271 | fn find_matching_normal_impls<'c>(
    |                               ^^
272 |     constraint: &TraitConstraint, bindings: &UnificationBindings, fuel: u32, cache: &mut ModuleCache<'c>,
    |                                                                                                      ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
271 ~ fn find_matching_normal_impls(
272 ~     constraint: &TraitConstraint, bindings: &UnificationBindings, fuel: u32, cache: &mut ModuleCache<'_>,
    |

warning: the following explicit lifetimes could be elided: 'c
   --> src/types/traitchecker.rs:311:28
    |
311 | fn check_given_constraints<'c>(
    |                            ^^
312 |     constraint: &TraitConstraint, impl_id: ImplInfoId, mut unification_bindings: UnificationBindings,
313 |     mut impl_bindings: TypeBindings, fuel: u32, cache: &mut ModuleCache<'c>,
    |                                                                         ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
311 ~ fn check_given_constraints(
312 |     constraint: &TraitConstraint, impl_id: ImplInfoId, mut unification_bindings: UnificationBindings,
313 ~     mut impl_bindings: TypeBindings, fuel: u32, cache: &mut ModuleCache<'_>,
    |

warning: the following explicit lifetimes could be elided: 'b
   --> src/types/traits.rs:127:30
    |
127 |     pub fn find_all_typevars<'b>(&self, cache: &ModuleCache<'b>) -> Vec<TypeVariableId> {
    |                              ^^                             ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
127 -     pub fn find_all_typevars<'b>(&self, cache: &ModuleCache<'b>) -> Vec<TypeVariableId> {
127 +     pub fn find_all_typevars(&self, cache: &ModuleCache<'_>) -> Vec<TypeVariableId> {
    |

warning: the following explicit lifetimes could be elided: 'b
   --> src/types/traits.rs:142:30
    |
142 |     pub fn find_all_typevars<'b>(&self, cache: &ModuleCache<'b>) -> Vec<TypeVariableId> {
    |                              ^^                             ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
142 -     pub fn find_all_typevars<'b>(&self, cache: &ModuleCache<'b>) -> Vec<TypeVariableId> {
142 +     pub fn find_all_typevars(&self, cache: &ModuleCache<'_>) -> Vec<TypeVariableId> {
    |

warning: the following explicit lifetimes could be elided: 'c
   --> src/types/typechecker.rs:138:34
    |
138 | pub fn type_application_bindings<'c>(info: &TypeInfo<'c>, typeargs: &[Type], cache: &ModuleCache) -> TypeBindings {
    |                                  ^^                  ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
138 - pub fn type_application_bindings<'c>(info: &TypeInfo<'c>, typeargs: &[Type], cache: &ModuleCache) -> TypeBindings {
138 + pub fn type_application_bindings(info: &TypeInfo<'_>, typeargs: &[Type], cache: &ModuleCache) -> TypeBindings {
    |

warning: the following explicit lifetimes could be elided: 'c
   --> src/types/typechecker.rs:163:21
    |
163 | fn replace_typevars<'c>(
    |                     ^^
164 |     typ: &Type, typevars_to_replace: &HashMap<TypeVariableId, TypeVariableId>, cache: &ModuleCache<'c>,
    |                                                                                                    ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
163 ~ fn replace_typevars(
164 ~     typ: &Type, typevars_to_replace: &HashMap<TypeVariableId, TypeVariableId>, cache: &ModuleCache<'_>,
    |

warning: the following explicit lifetimes could be elided: 'c
   --> src/types/typechecker.rs:177:29
    |
177 | pub fn replace_all_typevars<'c>(types: &[Type], cache: &mut ModuleCache<'c>) -> (Vec<Type>, TypeBindings) {
    |                             ^^                                          ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
177 - pub fn replace_all_typevars<'c>(types: &[Type], cache: &mut ModuleCache<'c>) -> (Vec<Type>, TypeBindings) {
177 + pub fn replace_all_typevars(types: &[Type], cache: &mut ModuleCache<'_>) -> (Vec<Type>, TypeBindings) {
    |

warning: the following explicit lifetimes could be elided: 'c
   --> src/types/typechecker.rs:186:43
    |
186 | pub fn replace_all_typevars_with_bindings<'c>(
    |                                           ^^
187 |     typ: &Type, new_bindings: &mut TypeBindings, cache: &mut ModuleCache<'c>,
    |                                                                          ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
186 ~ pub fn replace_all_typevars_with_bindings(
187 ~     typ: &Type, new_bindings: &mut TypeBindings, cache: &mut ModuleCache<'_>,
    |

warning: the following explicit lifetimes could be elided: 'c
   --> src/types/typechecker.rs:242:33
    |
242 | fn replace_typevar_with_binding<'c>(
    |                                 ^^
243 |     id: TypeVariableId, new_bindings: &mut TypeBindings, default: fn(TypeVariableId) -> Type,
244 |     cache: &mut ModuleCache<'c>,
    |                             ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
242 ~ fn replace_typevar_with_binding(
243 |     id: TypeVariableId, new_bindings: &mut TypeBindings, default: fn(TypeVariableId) -> Type,
244 ~     cache: &mut ModuleCache<'_>,
    |

warning: the following explicit lifetimes could be elided: 'c
   --> src/types/typechecker.rs:262:22
    |
262 | pub fn bind_typevars<'c>(typ: &Type, type_bindings: &TypeBindings, cache: &ModuleCache<'c>) -> Type {
    |                      ^^                                                                ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
262 - pub fn bind_typevars<'c>(typ: &Type, type_bindings: &TypeBindings, cache: &ModuleCache<'c>) -> Type {
262 + pub fn bind_typevars(typ: &Type, type_bindings: &TypeBindings, cache: &ModuleCache<'_>) -> Type {
    |

warning: the following explicit lifetimes could be elided: 'c
   --> src/types/typechecker.rs:324:17
    |
324 | fn bind_typevar<'c>(
    |                 ^^
325 |     id: TypeVariableId, type_bindings: &TypeBindings, default: fn(TypeVariableId) -> Type, cache: &ModuleCache<'c>,
    |                                                                                                                ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
324 ~ fn bind_typevar(
325 ~     id: TypeVariableId, type_bindings: &TypeBindings, default: fn(TypeVariableId) -> Type, cache: &ModuleCache<'_>,
    |

warning: the following explicit lifetimes could be elided: 'c
   --> src/types/typechecker.rs:345:40
    |
345 | pub fn contains_any_typevars_from_list<'c>(typ: &Type, list: &[TypeVariableId], cache: &ModuleCache<'c>) -> bool {
    |                                        ^^                                                           ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
345 - pub fn contains_any_typevars_from_list<'c>(typ: &Type, list: &[TypeVariableId], cache: &ModuleCache<'c>) -> bool {
345 + pub fn contains_any_typevars_from_list(typ: &Type, list: &[TypeVariableId], cache: &ModuleCache<'_>) -> bool {
    |

warning: the following explicit lifetimes could be elided: 'c
   --> src/types/typechecker.rs:373:50
    |
373 | fn type_variable_contains_any_typevars_from_list<'c>(
    |                                                  ^^
374 |     id: TypeVariableId, list: &[TypeVariableId], cache: &ModuleCache<'c>,
    |                                                                      ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
373 ~ fn type_variable_contains_any_typevars_from_list(
374 ~     id: TypeVariableId, list: &[TypeVariableId], cache: &ModuleCache<'_>,
    |

warning: the following explicit lifetimes could be elided: 'b
   --> src/types/typechecker.rs:430:24
    |
430 |     pub fn instantiate<'b>(
    |                        ^^
431 |         &self, mut constraints: TraitConstraints, cache: &mut ModuleCache<'b>,
    |                                                                           ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
430 ~     pub fn instantiate(
431 ~         &self, mut constraints: TraitConstraints, cache: &mut ModuleCache<'_>,
    |

warning: the following explicit lifetimes could be elided: 'b
   --> src/types/typechecker.rs:470:35
    |
470 | fn instantiate_impl_with_bindings<'b>(
    |                                   ^^
471 |     typ: &GeneralizedType, bindings: &mut TypeBindings, cache: &mut ModuleCache<'b>,
    |                                                                                 ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
470 ~ fn instantiate_impl_with_bindings(
471 ~     typ: &GeneralizedType, bindings: &mut TypeBindings, cache: &mut ModuleCache<'_>,
    |

warning: the following explicit lifetimes could be elided: 'b
   --> src/types/typechecker.rs:483:17
    |
483 | fn find_binding<'b>(id: TypeVariableId, map: &UnificationBindings, cache: &ModuleCache<'b>) -> TypeBinding {
    |                 ^^                                                                     ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
483 - fn find_binding<'b>(id: TypeVariableId, map: &UnificationBindings, cache: &ModuleCache<'b>) -> TypeBinding {
483 + fn find_binding(id: TypeVariableId, map: &UnificationBindings, cache: &ModuleCache<'_>) -> TypeBinding {
    |

warning: the following explicit lifetimes could be elided: 'b
   --> src/types/typechecker.rs:538:22
    |
538 | pub(super) fn occurs<'b>(
    |                      ^^
539 |     id: TypeVariableId, level: LetBindingLevel, typ: &Type, bindings: &mut UnificationBindings, fuel: u32,
540 |     cache: &mut ModuleCache<'b>,
    |                             ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
538 ~ pub(super) fn occurs(
539 |     id: TypeVariableId, level: LetBindingLevel, typ: &Type, bindings: &mut UnificationBindings, fuel: u32,
540 ~     cache: &mut ModuleCache<'_>,
    |

warning: the following explicit lifetimes could be elided: 'c
   --> src/types/typechecker.rs:569:30
    |
569 | pub(super) fn typevars_match<'c>(
    |                              ^^
570 |     needle: TypeVariableId, level: LetBindingLevel, haystack: TypeVariableId, bindings: &mut UnificationBindings,
571 |     fuel: u32, cache: &mut ModuleCache<'c>,
    |                                        ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
569 ~ pub(super) fn typevars_match(
570 |     needle: TypeVariableId, level: LetBindingLevel, haystack: TypeVariableId, bindings: &mut UnificationBindings,
571 ~     fuel: u32, cache: &mut ModuleCache<'_>,
    |

warning: the following explicit lifetimes could be elided: 'b
   --> src/types/typechecker.rs:583:41
    |
583 | pub fn follow_bindings_in_cache_and_map<'b>(
    |                                         ^^
584 |     typ: &Type, bindings: &UnificationBindings, cache: &ModuleCache<'b>,
    |                                                                     ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
583 ~ pub fn follow_bindings_in_cache_and_map(
584 ~     typ: &Type, bindings: &UnificationBindings, cache: &ModuleCache<'_>,
    |

warning: the following explicit lifetimes could be elided: 'b
   --> src/types/typechecker.rs:595:33
    |
595 | pub fn follow_bindings_in_cache<'b>(typ: &Type, cache: &ModuleCache<'b>) -> Type {
    |                                 ^^                                  ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
595 - pub fn follow_bindings_in_cache<'b>(typ: &Type, cache: &ModuleCache<'b>) -> Type {
595 + pub fn follow_bindings_in_cache(typ: &Type, cache: &ModuleCache<'_>) -> Type {
    |

warning: this returns a `Result<_, ()>`
   --> src/types/typechecker.rs:615:1
    |
615 | / pub fn try_unify_with_bindings_inner<'b>(
616 | |     t1: &Type, t2: &Type, bindings: &mut UnificationBindings, location: Location<'b>, cache: &mut ModuleCache<'b>,
617 | | ) -> Result<(), ()> {
    | |___________________^
    |
    = help: use a custom `Error` type instead
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#result_unit_err

warning: the following explicit lifetimes could be elided: 'c
   --> src/types/typechecker.rs:790:15
    |
790 | fn get_fields<'c>(
    |               ^^
791 |     typ: &Type, args: &[Type], bindings: &mut UnificationBindings, cache: &mut ModuleCache<'c>,
    |                                                                                            ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
790 ~ fn get_fields(
791 ~     typ: &Type, args: &[Type], bindings: &mut UnificationBindings, cache: &mut ModuleCache<'_>,
    |

warning: the following explicit lifetimes could be elided: 'c
   --> src/types/typechecker.rs:911:24
    |
911 | fn concat_type_strings<'c>(types: &[Type], cache: &ModuleCache<'c>) -> String {
    |                        ^^                                      ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
911 - fn concat_type_strings<'c>(types: &[Type], cache: &ModuleCache<'c>) -> String {
911 + fn concat_type_strings(types: &[Type], cache: &ModuleCache<'_>) -> String {
    |

warning: the borrowed expression implements the required traits
   --> src/types/typechecker.rs:913:15
    |
913 |     join_with(&types, ", ")
    |               ^^^^^^ help: change this to: `types`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: the following explicit lifetimes could be elided: 'a
   --> src/types/typechecker.rs:950:26
    |
950 | pub fn find_all_typevars<'a>(typ: &Type, polymorphic_only: bool, cache: &ModuleCache<'a>) -> Vec<TypeVariableId> {
    |                          ^^                                                          ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
950 - pub fn find_all_typevars<'a>(typ: &Type, polymorphic_only: bool, cache: &ModuleCache<'a>) -> Vec<TypeVariableId> {
950 + pub fn find_all_typevars(typ: &Type, polymorphic_only: bool, cache: &ModuleCache<'_>) -> Vec<TypeVariableId> {
    |

warning: the following explicit lifetimes could be elided: 'a
    --> src/types/typechecker.rs:1004:32
     |
1004 | fn find_all_typevars_in_traits<'a>(traits: &TraitConstraints, cache: &ModuleCache<'a>) -> Vec<TypeVariableId> {
     |                                ^^                                                 ^^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
     |
1004 - fn find_all_typevars_in_traits<'a>(traits: &TraitConstraints, cache: &ModuleCache<'a>) -> Vec<TypeVariableId> {
1004 + fn find_all_typevars_in_traits(traits: &TraitConstraints, cache: &ModuleCache<'_>) -> Vec<TypeVariableId> {
     |

warning: the following explicit lifetimes could be elided: 'a
    --> src/types/typechecker.rs:1016:15
     |
1016 | fn generalize<'a>(typ: &Type, cache: &ModuleCache<'a>) -> GeneralizedType {
     |               ^^                                  ^^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
     |
1016 - fn generalize<'a>(typ: &Type, cache: &ModuleCache<'a>) -> GeneralizedType {
1016 + fn generalize(typ: &Type, cache: &ModuleCache<'_>) -> GeneralizedType {
     |

warning: the following explicit lifetimes could be elided: 'c
    --> src/types/typechecker.rs:1104:29
     |
1104 | fn bind_closure_environment<'c>(environment: &mut ClosureEnvironment, cache: &mut ModuleCache<'c>) {
     |                             ^^                                                                ^^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
     |
1104 - fn bind_closure_environment<'c>(environment: &mut ClosureEnvironment, cache: &mut ModuleCache<'c>) {
1104 + fn bind_closure_environment(environment: &mut ClosureEnvironment, cache: &mut ModuleCache<'_>) {
     |

warning: the following explicit lifetimes could be elided: 'c
    --> src/types/typechecker.rs:1120:30
     |
1120 | fn infer_closure_environment<'c>(environment: &ClosureEnvironment, cache: &mut ModuleCache<'c>) -> Type {
     |                              ^^                                                            ^^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
     |
1120 - fn infer_closure_environment<'c>(environment: &ClosureEnvironment, cache: &mut ModuleCache<'c>) -> Type {
1120 + fn infer_closure_environment(environment: &ClosureEnvironment, cache: &mut ModuleCache<'_>) -> Type {
     |

warning: you seem to be trying to pop elements from a `Vec` in a loop
    --> src/types/typechecker.rs:1143:9
     |
1143 |         let typ = types.pop().unwrap();
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_while_let_some
     = note: `#[warn(clippy::manual_while_let_some)]` on by default
help: consider using a `while..let` loop
     |
1142 ~     while let Some(typ) = types.pop() {
1143 ~         
     |

warning: the following explicit lifetimes could be elided: 'a
    --> src/types/typechecker.rs:1235:36
     |
1235 | fn lookup_definition_type_in_trait<'a>(
     |                                    ^^
1236 |     name: &str, trait_id: TraitInfoId, cache: &mut ModuleCache<'a>,
     |                                                                ^^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
     |
1235 ~ fn lookup_definition_type_in_trait(
1236 ~     name: &str, trait_id: TraitInfoId, cache: &mut ModuleCache<'_>,
     |

warning: the following explicit lifetimes could be elided: 'c
    --> src/types/typechecker.rs:1271:27
     |
1271 | fn infer_trait_definition<'c>(name: &str, trait_id: TraitInfoId, cache: &mut ModuleCache<'c>) -> GeneralizedType {
     |                           ^^                                                             ^^
     |
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
     |
1271 - fn infer_trait_definition<'c>(name: &str, trait_id: TraitInfoId, cache: &mut ModuleCache<'c>) -> GeneralizedType {
1271 + fn infer_trait_definition(name: &str, trait_id: TraitInfoId, cache: &mut ModuleCache<'_>) -> GeneralizedType {
     |

warning: the following explicit lifetimes could be elided: 'b
  --> src/types/typeprinter.rs:63:29
   |
63 | pub fn show_type_and_traits<'b>(
   |                             ^^
64 |     typ: &GeneralizedType, traits: &[RequiredTrait], trait_info: &Option<(TraitInfoId, Vec<Type>)>,
65 |     cache: &ModuleCache<'b>,
   |                         ^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
   |
63 ~ pub fn show_type_and_traits(
64 |     typ: &GeneralizedType, traits: &[RequiredTrait], trait_info: &Option<(TraitInfoId, Vec<Type>)>,
65 ~     cache: &ModuleCache<'_>,
   |

warning: the following explicit lifetimes could be elided: 'c
   --> src/types/mod.rs:174:20
    |
174 |     pub fn is_unit<'c>(&self, cache: &ModuleCache<'c>) -> bool {
    |                    ^^                             ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
174 -     pub fn is_unit<'c>(&self, cache: &ModuleCache<'c>) -> bool {
174 +     pub fn is_unit(&self, cache: &ModuleCache<'_>) -> bool {
    |

warning: the following explicit lifetimes could be elided: 'c
   --> src/types/mod.rs:185:37
    |
185 |     pub fn is_union_constructor<'a, 'c>(&'a self, cache: &'a ModuleCache<'c>) -> bool {
    |                                     ^^                                   ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
185 -     pub fn is_union_constructor<'a, 'c>(&'a self, cache: &'a ModuleCache<'c>) -> bool {
185 +     pub fn is_union_constructor<'a>(&'a self, cache: &'a ModuleCache<'_>) -> bool {
    |

warning: the following explicit lifetimes could be elided: 'c
   --> src/types/mod.rs:190:43
    |
190 |     pub fn union_constructor_variants<'a, 'c>(
    |                                           ^^
191 |         &'a self, cache: &'a ModuleCache<'c>,
    |                                          ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
190 ~     pub fn union_constructor_variants<'a>(
191 ~         &'a self, cache: &'a ModuleCache<'_>,
    |

warning: you seem to want to iterate on a map's values
   --> src/types/mod.rs:261:33
    |
261 |                 for (_, typ) in fields {
    |                                 ^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#for_kv_map
    = note: `#[warn(clippy::for_kv_map)]` on by default
help: use the corresponding method
    |
261 |                 for typ in fields.values() {
    |                     ~~~    ~~~~~~~~~~~~~~~

warning: you seem to want to iterate on a map's values
   --> src/types/mod.rs:302:33
    |
302 |                 for (_, typ) in fields {
    |                                 ^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#for_kv_map
help: use the corresponding method
    |
302 |                 for typ in fields.values() {
    |                     ~~~    ~~~~~~~~~~~~~~~

warning: the following explicit lifetimes could be elided: 'c
   --> src/types/mod.rs:378:37
    |
378 |     pub fn is_union_constructor<'a, 'c>(&'a self, cache: &'a ModuleCache<'c>) -> bool {
    |                                     ^^                                   ^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
help: elide the lifetimes
    |
378 -     pub fn is_union_constructor<'a, 'c>(&'a self, cache: &'a ModuleCache<'c>) -> bool {
378 +     pub fn is_union_constructor<'a>(&'a self, cache: &'a ModuleCache<'_>) -> bool {
    |

warning: `ante` (lib) generated 71 warnings
error: could not compile `ante` (lib) due to 2 previous errors; 71 warnings emitted
```
</details>

<details>
<summary>Remaining errors after this PR</summary>

```rust
warning: this returns a `Result<_, ()>`
   --> src/nameresolution/mod.rs:627:5
    |
627 |     pub fn start(ast: Ast<'c>, cache: &mut ModuleCache<'c>) -> Result<(), ()> {
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: use a custom `Error` type instead
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#result_unit_err
    = note: `#[warn(clippy::result_unit_err)]` on by default

warning: this returns a `Result<_, ()>`
   --> src/types/typechecker.rs:613:1
    |
613 | / pub fn try_unify_with_bindings_inner<'b>(
614 | |     t1: &Type, t2: &Type, bindings: &mut UnificationBindings, location: Location<'b>, cache: &mut ModuleCache<'b>,
615 | | ) -> Result<(), ()> {
    | |___________________^
    |
    = help: use a custom `Error` type instead
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#result_unit_err

warning: `ante` (lib) generated 2 warnings
warning: parameter is only used in recursion
   --> src/cranelift_backend/context.rs:499:14
    |
499 |         &mut self, target_type: &Type, slot: StackSlot, offset: &mut u32, builder: &mut FunctionBuilder,
    |              ^^^^
    |
note: parameter used here
   --> src/cranelift_backend/context.rs:508:67
    |
508 |             Type::Tuple(elems) => Value::Tuple(fmap(elems, |elem| self.load_stack_value(elem, slot, offset, builder))),
    |                                                                   ^^^^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#only_used_in_recursion
    = note: `#[warn(clippy::only_used_in_recursion)]` on by default

warning: parameter is only used in recursion
   --> src/cranelift_backend/context.rs:515:14
    |
515 |         &mut self, target_type: &Type, addr: CraneliftValue, offset: &mut i32, builder: &mut FunctionBuilder,
    |              ^^^^
    |
note: parameter used here
   --> src/cranelift_backend/context.rs:524:67
    |
524 |             Type::Tuple(elems) => Value::Tuple(fmap(elems, |elem| self.load_value(elem, addr, offset, builder))),
    |                                                                   ^^^^
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#only_used_in_recursion

warning: `ante` (bin "ante") generated 2 warnings
```
</details>