### PR TITLE
Update flake to include the language server #179

### DIFF
--- a/ante-ls/Cargo.toml
+++ b/ante-ls/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-ante = { path = ".." }
+ante = { path = "..", default-features = false }
 dashmap = "5.5.3"
 env_logger = "0.10.2"
 futures = "0.3.30"

--- a/crates.nix
+++ b/crates.nix
@@ -1,13 +1,21 @@
-{ ... }: {
-  perSystem = { pkgs, lib, ... }: {
+{
+  perSystem = { pkgs, lib, config, ... }: {
     nci =
       let
         llvmPackages = pkgs.llvmPackages_16;
         major = lib.versions.major llvmPackages.llvm.version;
         minor = lib.versions.minor llvmPackages.llvm.version;
         llvm-sys-ver = "${major}${builtins.substring 0 1 minor}";
-        env = {
-          "LLVM_SYS_${llvm-sys-ver}_PREFIX" = llvmPackages.llvm.dev;
+        env = { "LLVM_SYS_${llvm-sys-ver}_PREFIX" = llvmPackages.llvm.dev; };
+
+        stdlib = pkgs.stdenv.mkDerivation {
+          pname = "ante-stdlib";
+          version = config.packages.ante.version;
+          src = ./stdlib;
+          phases = [ "unpackPhase" "installPhase" ];
+          installPhase = ''
+            find . -type f -exec install -Dm644 "{}" -t $out/lib \;
+          '';
         };
       in
       {
@@ -15,39 +23,54 @@
           channel = "stable";
           components = [ "rust-analyzer" "clippy" "rustfmt" "rust-src" ];
         };
-        projects.ante.path = ./.;
-        crates.ante = {
-          depsDrvConfig = {
-            inherit env;
-          };
-          drvConfig = {
-            inherit env;
-            mkDerivation = {
-              nativeBuildInputs = [ pkgs.installShellFiles ];
-              buildInputs = lib.attrValues
-                {
-                  inherit (pkgs)
-                    libffi
-                    libxml2
-                    ncurses;
-                } ++ [ llvmPackages.llvm ];
 
-              postPatch = ''
-                substituteInPlace tests/golden_tests.rs --replace \
-                  'target/debug' "target/$(rustc -vV | sed -n 's|host: ||p')/release"
-              '';
+        projects.ante = {
+          export = false;
+          path = ./.;
+        };
 
+        crates = {
+          ante-ls = {
+            profiles.release.features = [ ];
+            drvConfig.mkDerivation = {
               preBuild = ''
-                export ANTE_STDLIB_DIR=$out/lib
-                find stdlib -type f -exec install -Dm644 "{}" -t $ANTE_STDLIB_DIR \;
+                export ANTE_STDLIB_DIR=${stdlib}/lib
               '';
+            };
+          };
 
-              postInstall = ''
-                installShellCompletion --cmd ante \
-                  --bash <($out/bin/ante --shell-completion bash) \
-                  --fish <($out/bin/ante --shell-completion fish) \
-                  --zsh <($out/bin/ante --shell-completion zsh)
-              '';
+          ante = {
+            depsDrvConfig = {
+              inherit env;
+            };
+            drvConfig = {
+              inherit env;
+              mkDerivation = {
+                nativeBuildInputs = [ pkgs.installShellFiles ];
+                buildInputs = lib.attrValues
+                  {
+                    inherit (pkgs)
+                      libffi
+                      libxml2
+                      ncurses;
+                  } ++ [ llvmPackages.llvm stdlib ];
+
+                postPatch = ''
+                  substituteInPlace tests/golden_tests.rs --replace \
+                    'target/debug' "target/$(rustc -vV | sed -n 's|host: ||p')/release"
+                '';
+
+                preBuild = ''
+                  export ANTE_STDLIB_DIR=${stdlib}/lib
+                '';
+
+                postInstall = ''
+                  installShellCompletion --cmd ante \
+                    --bash <($out/bin/ante --shell-completion bash) \
+                    --fish <($out/bin/ante --shell-completion fish) \
+                    --zsh <($out/bin/ante --shell-completion zsh)
+                '';
+              };
             };
           };
         };

--- a/flake.nix
+++ b/flake.nix
@@ -31,11 +31,22 @@
       ];
 
       perSystem = { config, ... }:
-        let crateOutputs = config.nci.outputs.ante; in
+        let
+          anteCrate = config.nci.outputs.ante;
+          ante-lsCrate = config.nci.outputs.ante-ls;
+        in
         {
-          overlayAttrs.ante = config.packages.default;
-          packages.default = crateOutputs.packages.release;
-          devShells.default = crateOutputs.devShell.overrideAttrs (_: {
+          overlayAttrs = {
+            inherit (config.packages)
+              ante
+              ante-ls;
+          };
+          packages = rec {
+            default = ante;
+            ante = anteCrate.packages.release;
+            ante-ls = ante-lsCrate.packages.release;
+          };
+          devShells.default = anteCrate.devShell.overrideAttrs (_: {
             shellHook = ''
               PATH=$PATH:$PWD/target/debug
             '';


### PR DESCRIPTION
Updated the flake to also provide an `ante-ls` output and did some basic cleaning up of the existing package outputs. We might eventually want to move the language server to a separate repository, but in the meantime there's no harm in having the main flake provide it as well.