### PR TITLE
Add a file cache

### DIFF
--- a/ante-ls/src/main.rs
+++ b/ante-ls/src/main.rs
@@ -1,11 +1,11 @@
 use std::{
     collections::HashMap,
-    env::{current_dir, set_current_dir},
+    env::set_current_dir,
     path::{Path, PathBuf},
 };
 
 use ante::{
-    cache::ModuleCache,
+    cache::{cached_read, ModuleCache},
     error::{location::Locatable, ErrorType},
     lexer::Lexer,
     nameresolution::NameResolver,
@@ -73,9 +73,6 @@ impl LanguageServer for Backend {
         self.update_diagnostics(params.text_document.uri, &rope).await;
     }
 
-    // The diagnostics can't be updated on change, because the content of the file in the file system
-    // is not guaranteed to be the same as the content of the file in the editor. This will result in
-    // a panic when running Diagnostic::format, and the column are lengths different than expected.
     async fn did_change(&self, params: DidChangeTextDocumentParams) {
         self.client.log_message(MessageType::LOG, format!("ante_ls did_change: {:?}", params)).await;
         self.document_map.alter(&params.text_document.uri, |_, mut rope| {
@@ -90,25 +87,9 @@ impl LanguageServer for Backend {
             }
             rope
         });
-    }
-}
-
-fn relative_path<P1: AsRef<Path>, P2: AsRef<Path>>(root: P1, path: P2) -> Option<PathBuf> {
-    let path = path.as_ref();
-    if let Ok(path) = path.strip_prefix(&root) {
-        return Some(path.to_path_buf());
-    }
-
-    let mut acc = PathBuf::new();
-    let mut root = root.as_ref();
-    loop {
-        if let Ok(path) = path.strip_prefix(root) {
-            acc.push(path);
-            return Some(acc);
-        } else {
-            acc.push("..");
-            root = root.parent()?;
-        }
+        if let Some(rope) = self.document_map.get(&params.text_document.uri) {
+            self.update_diagnostics(params.text_document.uri, &rope).await;
+        };
     }
 }
 
@@ -147,20 +128,20 @@ fn rope_range_to_lsp_range(range: std::ops::Range<usize>, rope: &Rope) -> Range 
 
 impl Backend {
     async fn update_diagnostics(&self, uri: Url, rope: &Rope) {
-        let root = match current_dir() {
-            Ok(root) => root,
-            Err(_) => {
-                self.client.log_message(MessageType::ERROR, "Failed to get current directory".to_string()).await;
-                return;
-            },
-        };
-        // We want the filename to be relative to the root for nicer error messages.
-        // This could fail on windows when the root is on a different drive than the file.
+        // Urls always contain ablsoute canonical paths, so there's no need to canonicalize them.
         let filename = Path::new(uri.path());
-        let filename = relative_path(&root, filename).unwrap();
+        let cache_root = filename.parent().unwrap();
 
-        let mut cache = ModuleCache::new(filename.parent().unwrap());
-        let tokens = Lexer::new(&filename, &rope.to_string()).collect::<Vec<_>>();
+        let (paths, contents) =
+            self.document_map.iter().fold((Vec::new(), Vec::new()), |(mut paths, mut contents), item| {
+                paths.push(PathBuf::from(item.key().path()));
+                contents.push(item.value().to_string());
+                (paths, contents)
+            });
+        let file_cache = paths.iter().zip(contents.into_iter()).map(|(p, c)| (p.as_path(), c)).collect();
+        let mut cache = ModuleCache::new(cache_root, file_cache);
+
+        let tokens = Lexer::new(filename, &rope.to_string()).collect::<Vec<_>>();
         match parse(&tokens) {
             Ok(ast) => {
                 NameResolver::start(ast, &mut cache);
@@ -186,7 +167,7 @@ impl Backend {
         // to generate a list of files in one, we could run the compiler on the root of the project.
         // That should provide an exhaustive list of diagnostics, and allow us to clear all diagnostics
         // for files that had none in the new list.
-        let mut diagnostics = HashMap::from([(uri, Vec::new())]);
+        let mut diagnostics = HashMap::from([(uri.clone(), Vec::new())]);
 
         for diagnostic in cache.get_diagnostics() {
             let severity = Some(match diagnostic.error_type() {
@@ -196,40 +177,26 @@ impl Backend {
             });
 
             let loc = diagnostic.locate();
-            let filename = root.join(loc.filename);
-            let filename = match filename.canonicalize() {
-                Ok(filename) => filename,
-                Err(_) => {
-                    self.client
-                        .log_message(
-                            MessageType::ERROR,
-                            format!("Diagnostics for file {filename:?}, but its path could not be canonicalized"),
-                        )
-                        .await;
-                    continue;
-                },
-            };
-            let uri = Url::from_file_path(filename).unwrap();
+            let uri = Url::from_file_path(loc.filename).unwrap();
 
             let rope = match self.document_map.get(&uri) {
                 Some(rope) => rope,
                 None => {
-                    // Can we somehow retrieve the file from the compiler rather than reading it again?
-                    // Or have the compiler go through the lsp server file buffer instead of reading it from the file system?
-                    let rope = Rope::from_str(&std::fs::read_to_string(uri.path()).unwrap());
-                    self.document_map.insert(uri.clone(), rope.clone());
+                    let contents = cached_read(&cache.file_cache, loc.filename).unwrap();
+                    let rope = Rope::from_str(&contents);
+                    self.document_map.insert(uri.clone(), rope);
                     self.document_map.get(&uri).unwrap()
                 },
             };
 
-            // TODO: This range seems to be off
             let range = rope_range_to_lsp_range(loc.start.index..loc.end.index, &rope);
+            let message = format!("{}", diagnostic.display(&cache));
 
             let diagnostic = Diagnostic {
                 code: None,
                 code_description: None,
                 data: None,
-                message: diagnostic.msg().to_string(),
+                message,
                 range,
                 related_information: None,
                 severity,
@@ -245,10 +212,18 @@ impl Backend {
             };
         }
 
-        join_all(
+        let handle = join_all(
             diagnostics.into_iter().map(|(uri, diagnostics)| self.client.publish_diagnostics(uri, diagnostics, None)),
-        )
-        .await;
+        );
+
+        for (path, content) in cache.file_cache {
+            let uri = Url::from_file_path(path).unwrap();
+            if self.document_map.get(&uri).is_none() {
+                self.document_map.insert(uri.clone(), Rope::from_str(&content));
+            }
+        }
+
+        handle.await;
     }
 }
 

--- a/examples/nameresolution/Trait.an
+++ b/examples/nameresolution/Trait.an
@@ -12,8 +12,8 @@ bar : Unit
 
 // args: --check
 // expected stderr:
-// examples/nameresolution/Trait.an:7:5	error: baz is not required by Foo
+// Trait.an:7:5	error: baz is not required by Foo
 //     baz = 2  // error: baz not in foo
 // 
-// examples/nameresolution/Trait.an:5:1	error: impl is missing a definition for bar
+// Trait.an:5:1	error: impl is missing a definition for bar
 // impl Foo I32 String with

--- a/examples/nameresolution/conflictingimport.an
+++ b/examples/nameresolution/conflictingimport.an
@@ -6,14 +6,14 @@ library_fn _ = 3
 
 // args: --check
 // expected stderr:
-// examples/nameresolution/conflictingimport.an:1:1	error: import shadows previous definition of library_fn
+// conflictingimport.an:1:1	error: import shadows previous definition of library_fn
 // import Library
 // 
-// examples/nameresolution/conflictingimport.an:5:1	note: library_fn was previously defined here
+// conflictingimport.an:5:1	note: library_fn was previously defined here
 // library_fn _ = 3
 // 
-// examples/nameresolution/conflictingimport.an:1:1	error: import shadows previous definition of library_int
+// conflictingimport.an:1:1	error: import shadows previous definition of library_int
 // import Library
 // 
-// examples/nameresolution/conflictingimport.an:3:1	note: library_int was previously defined here
+// conflictingimport.an:3:1	note: library_int was previously defined here
 // library_int = 1

--- a/examples/nameresolution/effects.an
+++ b/examples/nameresolution/effects.an
@@ -24,8 +24,8 @@ handle ()
 
 // args: --check
 // expected stderr:
-// examples/nameresolution/effects.an:12:1	error: Handler is missing 2 cases: two, three
+// effects.an:12:1	error: Handler is missing 2 cases: two, three
 // handle ()
 // 
-// examples/nameresolution/effects.an:21:1	error: Handler is missing 3 cases: one, two, get
+// effects.an:21:1	error: Handler is missing 3 cases: one, two, get
 // handle ()

--- a/examples/nameresolution/errors.an
+++ b/examples/nameresolution/errors.an
@@ -16,26 +16,26 @@ a = 3 // already declared
 
 // args: --check
 // expected stderr:
-// examples/nameresolution/errors.an:15:1	error: a is already in scope
+// errors.an:15:1	error: a is already in scope
 // a = 3 // already declared
 // 
-// examples/nameresolution/errors.an:14:1	note: a was previously defined here
+// errors.an:14:1	note: a was previously defined here
 // a = 2
 // 
-// examples/nameresolution/errors.an:4:14	error: No declaration for `is_an_error` was found in scope
+// errors.an:4:14	error: No declaration for `is_an_error` was found in scope
 // not_an_error is_an_error
 // 
-// examples/nameresolution/errors.an:6:15	error: No declaration for `c` was found in scope
+// errors.an:6:15	error: No declaration for `c` was found in scope
 // fn a b -> a + c + b
 // 
-// examples/nameresolution/errors.an:9:9	warning: c is unused (prefix name with _ to silence this warning)
+// errors.an:9:9	warning: c is unused (prefix name with _ to silence this warning)
 //     bar c d =
 // 
-// examples/nameresolution/errors.an:9:11	warning: d is unused (prefix name with _ to silence this warning)
+// errors.an:9:11	warning: d is unused (prefix name with _ to silence this warning)
 //     bar c d =
 // 
-// examples/nameresolution/errors.an:8:5	warning: a is unused (prefix name with _ to silence this warning)
+// errors.an:8:5	warning: a is unused (prefix name with _ to silence this warning)
 // foo a b =
 // 
-// examples/nameresolution/errors.an:9:5	warning: bar is unused (prefix name with _ to silence this warning)
+// errors.an:9:5	warning: bar is unused (prefix name with _ to silence this warning)
 //     bar c d =

--- a/examples/nameresolution/redeclare.an
+++ b/examples/nameresolution/redeclare.an
@@ -9,23 +9,23 @@ foo _ =
 
 // args: --check
 // expected stderr:
-// examples/nameresolution/redeclare.an:2:1	error: a is already in scope
+// redeclare.an:2:1	error: a is already in scope
 // a = 2
 // 
-// examples/nameresolution/redeclare.an:1:1	note: a was previously defined here
+// redeclare.an:1:1	note: a was previously defined here
 // a = 1
 // 
-// examples/nameresolution/redeclare.an:3:1	error: a is already in scope
+// redeclare.an:3:1	error: a is already in scope
 // a = 3
 // 
-// examples/nameresolution/redeclare.an:2:1	note: a was previously defined here
+// redeclare.an:2:1	note: a was previously defined here
 // a = 2
 // 
-// examples/nameresolution/redeclare.an:6:5	warning: a is unused (prefix name with _ to silence this warning)
+// redeclare.an:6:5	warning: a is unused (prefix name with _ to silence this warning)
 //     a = 4
 // 
-// examples/nameresolution/redeclare.an:5:1	warning: foo is unused (prefix name with _ to silence this warning)
+// redeclare.an:5:1	warning: foo is unused (prefix name with _ to silence this warning)
 // foo _ =
 // 
-// examples/nameresolution/redeclare.an:7:5	warning: a is unused (prefix name with _ to silence this warning)
+// redeclare.an:7:5	warning: a is unused (prefix name with _ to silence this warning)
 //     a = 5

--- a/examples/nameresolution/unused_warning.an
+++ b/examples/nameresolution/unused_warning.an
@@ -5,14 +5,14 @@ id x = error
 
 // args: --check
 // expected stderr:
-// examples/nameresolution/unused_warning.an:4:1	error: id is already in scope
+// unused_warning.an:4:1	error: id is already in scope
 // id x = error
 // 
-// examples/nameresolution/unused_warning.an:2:1	note: id was previously defined here
+// unused_warning.an:2:1	note: id was previously defined here
 // id x = x
 // 
-// examples/nameresolution/unused_warning.an:4:8	error: No declaration for `error` was found in scope
+// unused_warning.an:4:8	error: No declaration for `error` was found in scope
 // id x = error
 // 
-// examples/nameresolution/unused_warning.an:4:4	warning: x is unused (prefix name with _ to silence this warning)
+// unused_warning.an:4:4	warning: x is unused (prefix name with _ to silence this warning)
 // id x = error

--- a/examples/parsing/invalid_integer_literal_suffix.an
+++ b/examples/parsing/invalid_integer_literal_suffix.an
@@ -2,5 +2,5 @@
 
 // args: --check
 // expected stderr:
-// examples/parsing/invalid_integer_literal_suffix.an:1:1	error: Invalid suffix after integer literal. Expected an integer type like i32 or a space to separate the two tokens
+// invalid_integer_literal_suffix.an:1:1	error: Invalid suffix after integer literal. Expected an integer type like i32 or a space to separate the two tokens
 // 3_2_fdsa

--- a/examples/parsing/parse_error.an
+++ b/examples/parsing/parse_error.an
@@ -5,6 +5,6 @@ bar a b = if then else
 
 // args: --parse --no-color
 // expected stderr:
-// examples/parsing/parse_error.an:2:9	error: Parser expected 'then' here
+// parse_error.an:2:9	error: Parser expected 'then' here
 // if true else
 //         ^^^^

--- a/examples/regressions/146_invalid_int_type.an
+++ b/examples/regressions/146_invalid_int_type.an
@@ -2,5 +2,5 @@ a: Int String = 3
 
 // args: --check
 // expected stderr:
-// examples/regressions/146_invalid_int_type.an:1:4	error: Type String is not an integer type
+// 146_invalid_int_type.an:1:4	error: Type String is not an integer type
 // a: Int String = 3

--- a/examples/typechecking/completeness_checking.an
+++ b/examples/typechecking/completeness_checking.an
@@ -28,23 +28,23 @@ match (1, 2, 3, 4)
 // args: --check
 // TODO: First error can be improved. Should be "Missing case Some _"
 // expected stderr:
-// examples/typechecking/completeness_checking.an:2:1	error: Missing case _
+// completeness_checking.an:2:1	error: Missing case _
 // match None
 // 
-// examples/typechecking/completeness_checking.an:5:1	error: Missing case (_, None)
+// completeness_checking.an:5:1	error: Missing case (_, None)
 // match (2, None)
 // 
-// examples/typechecking/completeness_checking.an:18:4	warning: Unreachable pattern
+// completeness_checking.an:18:4	warning: Unreachable pattern
 // | (1, 2) -> 1
 // 
-// examples/typechecking/completeness_checking.an:16:1	error: Missing case (_ : Int, _)
+// completeness_checking.an:16:1	error: Missing case (_ : Int, _)
 // match (1, 2)
 // 
-// examples/typechecking/completeness_checking.an:20:1	error: Missing case (true, true)
+// completeness_checking.an:20:1	error: Missing case (true, true)
 // match (true, true)
 // 
-// examples/typechecking/completeness_checking.an:20:1	error: Missing case (false, false)
+// completeness_checking.an:20:1	error: Missing case (false, false)
 // match (true, true)
 // 
-// examples/typechecking/completeness_checking.an:25:4	error: This pattern of type ((Int a), (Int b)) does not match the type ((Int a), ((Int b), ((Int c), (Int d)))) that is being matched on
+// completeness_checking.an:25:4	error: This pattern of type ((Int a), (Int b)) does not match the type ((Int a), ((Int b), ((Int c), (Int d)))) that is being matched on
 // | (1, 2) -> 1

--- a/examples/typechecking/given_constraint_error.an
+++ b/examples/typechecking/given_constraint_error.an
@@ -4,5 +4,5 @@ impl Print a given DoesNotExist a with
 
 // args: --check
 // expected stderr:
-// examples/typechecking/given_constraint_error.an:2:20	error: Trait DoesNotExist was not found in scope
+// given_constraint_error.an:2:20	error: Trait DoesNotExist was not found in scope
 // impl Print a given DoesNotExist a with

--- a/examples/typechecking/impl.an
+++ b/examples/typechecking/impl.an
@@ -15,7 +15,7 @@ c = foo "one" "two"
 
 // args: --check --show-types
 // expected stderr:
-// examples/typechecking/impl.an:14:5	error: No impl found for Foo String
+// impl.an:14:5	error: No impl found for Foo String
 // c = foo "one" "two"
 // 
 

--- a/examples/typechecking/member_access.an
+++ b/examples/typechecking/member_access.an
@@ -17,7 +17,7 @@ foo_and_bar foo bar
 
 // args: --check --show-types
 // expected stderr:
-// examples/typechecking/member_access.an:16:17	error: Expected argument of type { bar: String, .. }, but found Bar
+// member_access.an:16:17	error: Expected argument of type { bar: String, .. }, but found Bar
 // foo_and_bar foo bar
 // 
 

--- a/examples/typechecking/multiple_matching_impls.an
+++ b/examples/typechecking/multiple_matching_impls.an
@@ -35,11 +35,11 @@ impl Foo Thing with
 
 // args: --check
 // expected stderr:
-// examples/typechecking/multiple_matching_impls.an:14:1	error: 2 matching impls found for Foo Thing
+// multiple_matching_impls.an:14:1	error: 2 matching impls found for Foo Thing
 // foo (Thing ())
 // 
-// examples/typechecking/multiple_matching_impls.an:17:1	note: Candidate 1
+// multiple_matching_impls.an:17:1	note: Candidate 1
 // impl Foo a given Bar a with
 // 
-// examples/typechecking/multiple_matching_impls.an:33:1	note: Candidate 2
+// multiple_matching_impls.an:33:1	note: Candidate 2
 // impl Foo Thing with

--- a/examples/typechecking/trait_impls.an
+++ b/examples/typechecking/trait_impls.an
@@ -26,7 +26,7 @@ bar "four" "five"
 
 // args: --check --show-types
 // expected stderr:
-// examples/typechecking/trait_impls.an:12:1	error: impl has 5 type arguments but Bar requires 2
+// trait_impls.an:12:1	error: impl has 5 type arguments but Bar requires 2
 // impl Bar I32 Char String F64 Unit with
 //
 // expected stdout:

--- a/examples/typechecking/trait_propagation.an
+++ b/examples/typechecking/trait_propagation.an
@@ -17,5 +17,5 @@ foo () = baz bar
 // foo : (forall a. (Unit -> Unit can a))
 
 // expected stderr:
-// examples/typechecking/trait_propagation.an:6:10	error: No impl found for Baz a
+// trait_propagation.an:6:10	error: No impl found for Baz a
 // foo () = baz bar

--- a/examples/typechecking/type_annotations.an
+++ b/examples/typechecking/type_annotations.an
@@ -17,7 +17,7 @@ puts2
 // TODO: bar should probably error that its annotated
 //       type is more general than its actual type
 // expected stderr:
-// examples/typechecking/type_annotations.an:13:7	error: Expected argument of type I32, but found String
+// type_annotations.an:13:7	error: Expected argument of type I32, but found String
 // exit2 "test"
 // 
 

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -25,6 +25,8 @@ use crate::types::{Type, TypeInfo, TypeInfoBody, TypeInfoId, TypeVariableId};
 use crate::util::stdlib_dir;
 
 use std::collections::{HashMap, HashSet};
+use std::fs::File;
+use std::io::{BufReader, Read};
 use std::path::{Path, PathBuf};
 
 use self::dependency_graph::DependencyGraph;
@@ -126,7 +128,12 @@ pub struct ModuleCache<'a> {
 
     /// The number of errors emitted by the program
     pub error_count: usize,
+
+    pub file_cache: FileCache<'a>,
 }
+
+pub type FileCache<'a> = HashMap<&'a Path, String>;
+// type MutCache<'a> = &'a mut HashMap<&'a Path, Box<str>>;
 
 #[derive(Debug)]
 pub struct MutualRecursionSet {
@@ -372,8 +379,21 @@ impl<'a> Locatable<'a> for EffectInfo<'a> {
     }
 }
 
+pub fn cached_read(file_cache: &FileCache<'_>, path: &Path) -> Option<String> {
+    file_cache.get(path).cloned().or_else(|| {
+        let file = File::open(path).ok()?;
+        let mut reader = BufReader::new(file);
+        let mut contents = String::new();
+        reader.read_to_string(&mut contents).ok()?;
+
+        Some(contents)
+    })
+}
+
 impl<'a> ModuleCache<'a> {
-    pub fn new(project_directory: &Path) -> ModuleCache<'a> {
+    /// For consistency, all paths should be absolute and canonical.
+    /// They can be converted to relative paths for displaying errors later.
+    pub fn new(project_directory: &Path, file_cache: FileCache<'a>) -> ModuleCache<'a> {
         ModuleCache {
             relative_roots: vec![project_directory.to_owned(), stdlib_dir()],
             // Really wish you could do ..Default::default() for the remaining fields
@@ -395,6 +415,7 @@ impl<'a> ModuleCache<'a> {
             global_dependency_graph: DependencyGraph::default(),
             diagnostics: Vec::new(),
             error_count: 0,
+            file_cache,
         }
     }
 
@@ -417,8 +438,21 @@ impl<'a> ModuleCache<'a> {
 
     pub fn display_diagnostics(&self) {
         for diagnostic in &self.diagnostics {
-            eprintln!("{}", diagnostic.display());
+            let diagnostic = diagnostic.display(self);
+            eprintln!("{}", diagnostic);
         }
+    }
+
+    pub fn get_contents(&mut self, path: &'a Path) -> Option<String> {
+        let contents = cached_read(&self.file_cache, path)?;
+        if !self.file_cache.contains_key(path) {
+            self.file_cache.insert(path, contents.clone());
+        };
+        Some(contents)
+    }
+
+    pub fn strip_root<'b>(&self, path: &'b Path) -> Option<&'b Path> {
+        self.relative_roots.iter().find_map(move |root| path.strip_prefix(root).ok())
     }
 
     #[allow(unused)]

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -133,7 +133,6 @@ pub struct ModuleCache<'a> {
 }
 
 pub type FileCache<'a> = HashMap<&'a Path, String>;
-// type MutCache<'a> = &'a mut HashMap<&'a Path, Box<str>>;
 
 #[derive(Debug)]
 pub struct MutualRecursionSet {

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -424,9 +424,7 @@ impl<'a> Diagnostic<'a> {
         let relative_path =
             os_agnostic_display_path(cache.strip_root(self.location.filename).unwrap_or(self.location.filename));
 
-        write!(f, "{}:{}:{}", relative_path, start.line, start.column)?;
-
-        writeln!(f, "\t{} {}", self.marker(), self.msg)?;
+        writeln!(f, "{}:{}:{}\t{} {}", relative_path, start.line, start.column, self.marker(), self.msg)?;
 
         let file_contents = cached_read(&cache.file_cache, self.location.filename).unwrap();
         let line = file_contents.lines().nth(max(1, start.line) as usize - 1).unwrap_or("");

--- a/src/frontend.rs
+++ b/src/frontend.rs
@@ -1,0 +1,73 @@
+use std::path::Path;
+
+use crate::cache::ModuleCache;
+use crate::lexer::Lexer;
+use crate::nameresolution::NameResolver;
+use crate::parser;
+use crate::types;
+use crate::util;
+
+#[derive(PartialEq)]
+pub enum FrontendPhase {
+    Lex,
+    Parse,
+    TypeCheck,
+}
+
+pub enum FrontendResult {
+    Done,
+    ContinueCompilation,
+    Errors,
+}
+
+pub fn check<'a>(
+    filename: &'a Path, main_file_contents: String, cache: &mut ModuleCache<'a>, phase: FrontendPhase, show_time: bool,
+) -> FrontendResult {
+    util::timing::time_passes(show_time);
+
+    // Phase 1: Lexing
+    util::timing::start_time("Lexing");
+    let tokens = Lexer::new(filename, &main_file_contents).collect::<Vec<_>>();
+
+    if phase == FrontendPhase::Lex {
+        tokens.iter().for_each(|(token, _)| println!("{}", token));
+        return FrontendResult::Done;
+    }
+
+    // Phase 2: Parsing
+    util::timing::start_time("Parsing");
+
+    let root = match parser::parse(&tokens) {
+        Ok(root) => root,
+        Err(parse_error) => {
+            // Parse errors are currently always fatal
+            cache.push_full_diagnostic(parse_error.into_diagnostic());
+            return FrontendResult::Errors;
+        },
+    };
+
+    if phase == FrontendPhase::Parse {
+        println!("{}", root);
+        return FrontendResult::Done;
+    }
+
+    // Phase 3: Name resolution
+    // Timing for name resolution is within the start method to
+    // break up the declare and define passes
+    NameResolver::start(root, cache);
+
+    if cache.error_count() != 0 {
+        return FrontendResult::Errors;
+    }
+
+    // Phase 4: Type inference
+    util::timing::start_time("Type Inference");
+    let ast = cache.parse_trees.get_mut(0).unwrap();
+    types::typechecker::infer_ast(ast, cache);
+
+    if cache.error_count() != 0 {
+        FrontendResult::Errors
+    } else {
+        FrontendResult::ContinueCompilation
+    }
+}

--- a/src/hir/monomorphisation.rs
+++ b/src/hir/monomorphisation.rs
@@ -694,7 +694,7 @@ impl<'c> Context<'c> {
                 &mut self.cache,
                 TE::MonomorphizationError,
             )
-            .unwrap_or_else(|error| panic!("ICE: {}", error.display()));
+            .unwrap_or_else(|error| panic!("ICE: {}", error.display(&self.cache)));
 
             self.monomorphisation_bindings.push(Rc::new(bindings.bindings));
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod lexer;
 
 #[macro_use]
 pub mod util;
+pub mod frontend;
 
 #[macro_use]
 pub mod error;


### PR DESCRIPTION
I've added a file cache to ModuleCache. That should allow for passing in memory buffers from the lsp to the compiler, and therefore updating diagnostics without having to wait for a file write. It also changes error messages to be relative paths from the root each module is in, and as such the expected errors for tests had to be updated.

Additionally, I've separated the check function into a frontend module that is reused in the language server like previously suggested.