### PR TITLE
Remove unneeded parenthesis

### DIFF
--- a/examples/regressions/129_int_defaulting_generalization.an
+++ b/examples/regressions/129_int_defaulting_generalization.an
@@ -12,9 +12,9 @@ second b + 2i64
 
 // args: --check --show-types
 // expected stdout:
-// a : (U64, I64)
-// b : (U64, I64)
-// c : (U64, I64)
+// a : U64, I64
+// b : U64, I64
+// c : U64, I64
 
 // Expected results with the function block uncommented:
 // f : (forall a. (Unit -> (U64, I64) can a))

--- a/examples/typechecking/bind.an
+++ b/examples/typechecking/bind.an
@@ -12,7 +12,7 @@ add_one x =
 
 // args: --check --show-types
 // expected stdout:
-// add_one : (forall a. ((Maybe I32) -> (Maybe I32) can a))
-// bind : (forall a b c d. ((Maybe c) - (c => (Maybe b) can d) -> (Maybe b) can d))
-// ret : (forall a b. (a -> (Maybe a) can b))
-// x : (Maybe I32)
+// add_one : forall a. (Maybe I32 -> Maybe I32 can a)
+// bind : forall a b c d. (Maybe c - (c => Maybe b can d) -> Maybe b can d)
+// ret : forall a b. (a -> Maybe a can b)
+// x : Maybe I32

--- a/examples/typechecking/completeness_checking.an
+++ b/examples/typechecking/completeness_checking.an
@@ -46,5 +46,5 @@ match (1, 2, 3, 4)
 // completeness_checking.an:20:1	error: Missing case (false, false)
 // match (true, true)
 // 
-// completeness_checking.an:25:4	error: This pattern of type ((Int a), (Int b)) does not match the type ((Int a), ((Int b), ((Int c), (Int d)))) that is being matched on
+// completeness_checking.an:25:4	error: This pattern of type Int a, Int b does not match the type Int a, Int b, Int c, Int d that is being matched on
 // | (1, 2) -> 1

--- a/examples/typechecking/effects.an
+++ b/examples/typechecking/effects.an
@@ -23,10 +23,10 @@ does_use x =
 
 // args: --check --show-types
 // expected stdout:
-// does_use : (forall a b. (a -> Unit can (Use a, b)))
+// does_use : forall a b. (a -> Unit can (Use a, b))
 //   given Add a
-// get : (forall a b. (Unit -> a can (Use a, b)))
-// handle_basic : (forall a. (Unit -> Unit can (Use String, a)))
-// log : (forall a. (String -> Unit can (Log, a)))
-// set : (forall a b. (a -> Unit can (Use a, b)))
-// use_resume : (forall a. (Unit -> Unit can a))
+// get : forall a b. (Unit -> a can (Use a, b))
+// handle_basic : forall a. (Unit -> Unit can (Use String, a))
+// log : forall a. (String -> Unit can (Log, a))
+// set : forall a b. (a -> Unit can (Use a, b))
+// use_resume : forall a. (Unit -> Unit can a)

--- a/examples/typechecking/extern.an
+++ b/examples/typechecking/extern.an
@@ -12,7 +12,7 @@ exit2 0
 
 // args: --check --show-types
 // expected stdout:
-// add : (forall a. (I32 - I32 -> I32 can a))
-// exit2 : (forall a b. (I32 -> a can b))
-// foo : (forall a b c. (a -> b can c))
-// puts2 : (forall a. (String -> Unit can a))
+// add : forall a. (I32 - I32 -> I32 can a)
+// exit2 : forall a b. (I32 -> a can b)
+// foo : forall a b c. (a -> b can c)
+// puts2 : forall a. (String -> Unit can a)

--- a/examples/typechecking/functor_and_monad.an
+++ b/examples/typechecking/functor_and_monad.an
@@ -23,9 +23,9 @@ impl Monad Maybe with
 
 // args: --check --show-types
 // expected stdout:
-// bind : (forall a b c d e. ((a b) - (b -> (a c) can d) -> (a c) can e))
+// bind : forall a b c d e. (a b - (b -> a c can d) -> a c can e)
 //   given Monad a
-// map : (forall a b c d e. ((a b) - (b -> c can d) -> (a c) can e))
+// map : forall a b c d e. (a b - (b -> c can d) -> a c can e)
 //   given Functor a
-// wrap : (forall a b c. (b -> (a b) can c))
+// wrap : forall a b c. (b -> a b can c)
 //   given Monad a

--- a/examples/typechecking/generalization.an
+++ b/examples/typechecking/generalization.an
@@ -6,4 +6,4 @@ foo x =
 
 // args: --check --show-types
 // expected stdout:
-// foo : (forall a b c d. (a -> (b => a can c) can d))
+// foo : forall a b c d. (a -> b => a can c can d)

--- a/examples/typechecking/impl.an
+++ b/examples/typechecking/impl.an
@@ -23,5 +23,5 @@ c = foo "one" "two"
 // a : I32
 // b : F64
 // c : String
-// foo : (forall a b. (a - a -> a can b))
+// foo : forall a b. (a - a -> a can b)
 //   given Foo a

--- a/examples/typechecking/instantiation.an
+++ b/examples/typechecking/instantiation.an
@@ -14,8 +14,8 @@ id x = x
 
 // args: --check --show-types
 // expected stdout:
-// add : (forall a b c d e f g h i. ((a - c => e can g) - (a - b => c can g) -> (a => (b => e can g) can h) can i))
-// id : (forall a b. (a -> a can b))
-// one : (forall a b c d. ((a => b can d) - a -> b can d))
-// two1 : (forall a b c. ((b => b can c) - b -> b can c))
-// two2 : ((a => a can c) => (a => a can c) can d)
+// add : forall a b c d e f g h i. ((a - c => e can g) - (a - b => c can g) -> a => b => e can g can h can i)
+// id : forall a b. (a -> a can b)
+// one : forall a b c d. ((a => b can d) - a -> b can d)
+// two1 : forall a b c. ((b => b can c) - b -> b can c)
+// two2 : (a => a can c) => a => a can c can d

--- a/examples/typechecking/member_access.an
+++ b/examples/typechecking/member_access.an
@@ -22,11 +22,11 @@ foo_and_bar foo bar
 // 
 
 // expected stdout:
-// Bar : (forall a. (Char -> Bar can a))
-// Foo : (forall a. (F64 -> Foo can a))
-// FooBar : (forall a. (I32 - String -> FooBar can a))
+// Bar : forall a. (Char -> Bar can a)
+// Foo : forall a. (F64 -> Foo can a)
+// FooBar : forall a. (I32 - String -> FooBar can a)
 // bar : Bar
 // foo : Foo
-// foo_and_bar : (forall a b c d. ({ foo: a, ..b } - { bar: String, ..c } -> String can d))
+// foo_and_bar : forall a b c d. ({ foo: a, ..b } - { bar: String, ..c } -> String can d)
 // foobar : FooBar
-// stringify : (forall a. (String -> String can a))
+// stringify : forall a. (String -> String can a)

--- a/examples/typechecking/mutual_recursion.an
+++ b/examples/typechecking/mutual_recursion.an
@@ -16,7 +16,7 @@ is_even 4
 // TODO: is_odd here uses `forall a c.` instead of `forall a b.`
 
 // expected stdout:
-// is_even : (forall a b. ((Int a) -> Bool can b))
-//   given Eq (Int a), Print (Int a), Sub (Int a)
-// is_odd : (forall a c. ((Int a) -> Bool can c))
-//   given Eq (Int a), Print (Int a), Sub (Int a)
+// is_even : forall a b. (Int a -> Bool can b)
+//   given Eq Int a, Print Int a, Sub Int a
+// is_odd : forall a c. (Int a -> Bool can c)
+//   given Eq Int a, Print Int a, Sub Int a

--- a/examples/typechecking/named_constructor.an
+++ b/examples/typechecking/named_constructor.an
@@ -8,6 +8,6 @@ foo = hello_foo 42
 
 // args: --check --show-types
 // expected stdout:
-// Foo : (forall a b c. (a - b -> (Foo a b) can c))
-// foo : (Foo String (Int a))
-// hello_foo : (forall a b. (a -> (Foo String a) can b))
+// Foo : forall a b c. (a - b -> Foo a b can c)
+// foo : Foo String Int a
+// hello_foo : forall a b. (a -> Foo String a can b)

--- a/examples/typechecking/named_constructor.an
+++ b/examples/typechecking/named_constructor.an
@@ -9,5 +9,5 @@ foo = hello_foo 42
 // args: --check --show-types
 // expected stdout:
 // Foo : forall a b c. (a - b -> Foo a b can c)
-// foo : Foo String Int a
+// foo : Foo String (Int a)
 // hello_foo : forall a b. (a -> Foo String a can b)

--- a/examples/typechecking/repeated_traits.an
+++ b/examples/typechecking/repeated_traits.an
@@ -5,5 +5,5 @@ foo a =
 // Make sure output is not "... given Print a, Print a"
 // args: --check --show-types
 // expected stdout:
-// foo : (forall a b. (a -> Unit can b))
+// foo : forall a b. (a -> Unit can b)
 //   given Print a

--- a/examples/typechecking/trait_fundep_result.an
+++ b/examples/typechecking/trait_fundep_result.an
@@ -9,6 +9,6 @@ str = foo 0i32
 
 // args: --check --show-types
 // expected stdout:
-// foo : (forall a b c. (a -> b can c))
+// foo : forall a b c. (a -> b can c)
 //   given Foo a b
 // str : String

--- a/examples/typechecking/trait_generalization.an
+++ b/examples/typechecking/trait_generalization.an
@@ -1,4 +1,4 @@
 a = "test".c_string
 
 // args: --check --show-types
-// expected stdout: a : (Ptr Char)
+// expected stdout: a : Ptr Char

--- a/examples/typechecking/trait_propagation.an
+++ b/examples/typechecking/trait_propagation.an
@@ -11,10 +11,10 @@ foo () = baz bar
 // 
 // args: --check --show-types
 // expected stdout:
-// bar : (forall a. a)
-// baz : (forall a b. (a -> Unit can b))
+// bar : forall a. a
+// baz : forall a b. (a -> Unit can b)
 //   given Baz a
-// foo : (forall a. (Unit -> Unit can a))
+// foo : forall a. (Unit -> Unit can a)
 
 // expected stderr:
 // trait_propagation.an:6:10	error: No impl found for Baz a

--- a/examples/typechecking/type_annotations.an
+++ b/examples/typechecking/type_annotations.an
@@ -22,8 +22,8 @@ puts2
 // 
 
 // expected stdout:
-// bar : (forall a. (I32 - I32 -> I32 can a))
-// baz : (forall a b. (Usz -> (Ptr a) can b))
-// exit2 : (forall a b. (I32 -> a can b))
-// foo : (forall a. (I32 - String -> Char can a))
-// puts2 : (forall a. ((Ptr Char) -> I32 can a))
+// bar : forall a. (I32 - I32 -> I32 can a)
+// baz : forall a b. (Usz -> Ptr a can b)
+// exit2 : forall a b. (I32 -> a can b)
+// foo : forall a. (I32 - String -> Char can a)
+// puts2 : forall a. (Ptr Char -> I32 can a)

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -45,8 +45,9 @@ impl std::fmt::Display for TypePriority {
 
 impl TypePriority {
     pub const MAX: TypePriority = TypePriority(u8::MAX);
-    pub const APP: TypePriority = TypePriority(3);
-    pub const FORALL: TypePriority = TypePriority(2);
+    pub const APP: TypePriority = TypePriority(4);
+    pub const FORALL: TypePriority = TypePriority(3);
+    pub const PAIR: TypePriority = TypePriority(2);
     pub const FUN: TypePriority = TypePriority(1);
 }
 
@@ -245,7 +246,13 @@ impl Type {
         match self {
             Primitive(_) | TypeVariable(_) | UserDefined(_) | Struct(_, _) | Tag(_) => TypePriority::MAX,
             Function(_) => TypePriority::FUN,
-            TypeApplication(_, _) => TypePriority::APP,
+            TypeApplication(ctor, _) => {
+                if ctor.is_pair_type() {
+                    TypePriority::PAIR
+                } else {
+                    TypePriority::APP
+                }
+            },
             Ref { .. } => TypePriority::APP,
             Effects(_) => unimplemented!("Type::priority for Effects"),
         }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -250,6 +250,8 @@ impl Type {
                 TypeBinding::Unbound(..) => TypePriority::MAX,
             },
             Function(_) => TypePriority::FUN,
+            TypeApplication(ctor, _) if ctor.is_polymorphic_int_type() => TypePriority::MAX,
+            TypeApplication(ctor, _) if ctor.is_polymorphic_float_type() => TypePriority::MAX,
             TypeApplication(ctor, _) => {
                 if ctor.is_pair_type() {
                     TypePriority::PAIR

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -250,21 +250,12 @@ impl Type {
                 TypeBinding::Unbound(..) => TypePriority::MAX,
             },
             Function(_) => TypePriority::FUN,
-            TypeApplication(ctor, args) if ctor.is_polymorphic_int_type() => {
+            TypeApplication(ctor, args) if ctor.is_polymorphic_int_type() || ctor.is_polymorphic_float_type() => {
                 if matches!(cache.follow_typebindings_shallow(&args[0]), Type::TypeVariable(_)) {
                     // type variable is unbound variable
                     TypePriority::APP
                 } else {
                     // type variable is bound (polymorphic int)
-                    TypePriority::MAX
-                }
-            },
-            TypeApplication(ctor, args) if ctor.is_polymorphic_float_type() => {
-                if matches!(cache.follow_typebindings_shallow(&args[0]), Type::TypeVariable(_)) {
-                    // type variable is unbound variable
-                    TypePriority::APP
-                } else {
-                    // type variable is bound (polymorphic float)
                     TypePriority::MAX
                 }
             },

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -241,10 +241,14 @@ impl Type {
         }
     }
 
-    pub fn priority(&self) -> TypePriority {
+    pub fn priority(&self, cache: &ModuleCache<'_>) -> TypePriority {
         use Type::*;
         match self {
-            Primitive(_) | TypeVariable(_) | UserDefined(_) | Struct(_, _) | Tag(_) => TypePriority::MAX,
+            Primitive(_) | UserDefined(_) | Struct(_, _) | Tag(_) => TypePriority::MAX,
+            TypeVariable(id) => match &cache.type_bindings[id.0] {
+                TypeBinding::Bound(typ) => typ.priority(cache),
+                TypeBinding::Unbound(..) => TypePriority::MAX,
+            },
             Function(_) => TypePriority::FUN,
             TypeApplication(ctor, _) => {
                 if ctor.is_pair_type() {
@@ -482,9 +486,9 @@ impl GeneralizedType {
         }
     }
 
-    pub fn priority(&self) -> TypePriority {
+    pub fn priority(&self, cache: &ModuleCache<'_>) -> TypePriority {
         match self {
-            GeneralizedType::MonoType(typ) => typ.priority(),
+            GeneralizedType::MonoType(typ) => typ.priority(cache),
             GeneralizedType::PolyType(..) => TypePriority::FORALL,
         }
     }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -250,8 +250,24 @@ impl Type {
                 TypeBinding::Unbound(..) => TypePriority::MAX,
             },
             Function(_) => TypePriority::FUN,
-            TypeApplication(ctor, _) if ctor.is_polymorphic_int_type() => TypePriority::MAX,
-            TypeApplication(ctor, _) if ctor.is_polymorphic_float_type() => TypePriority::MAX,
+            TypeApplication(ctor, args) if ctor.is_polymorphic_int_type() => {
+                if matches!(cache.follow_typebindings_shallow(&args[0]), Type::TypeVariable(_)) {
+                    // type variable is unbound variable
+                    TypePriority::APP
+                } else {
+                    // type variable is bound (polymorphic int)
+                    TypePriority::MAX
+                }
+            },
+            TypeApplication(ctor, args) if ctor.is_polymorphic_float_type() => {
+                if matches!(cache.follow_typebindings_shallow(&args[0]), Type::TypeVariable(_)) {
+                    // type variable is unbound variable
+                    TypePriority::APP
+                } else {
+                    // type variable is bound (polymorphic float)
+                    TypePriority::MAX
+                }
+            },
             TypeApplication(ctor, _) => {
                 if ctor.is_pair_type() {
                     TypePriority::PAIR

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -9,8 +9,8 @@ use std::collections::BTreeMap;
 use crate::cache::{DefinitionInfoId, ModuleCache};
 use crate::error::location::{Locatable, Location};
 use crate::lexer::token::{FloatKind, IntegerKind};
-use crate::util::fmap;
 use crate::util;
+use crate::util::fmap;
 
 use self::typeprinter::TypePrinter;
 use crate::types::effects::EffectSet;
@@ -26,6 +26,29 @@ pub mod typeprinter;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct TypeVariableId(pub usize);
+
+/// Priority of operator on Types
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct TypePriority(u8);
+
+impl From<u8> for TypePriority {
+    fn from(priority: u8) -> Self {
+        Self(priority)
+    }
+}
+
+impl std::fmt::Display for TypePriority {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "priority {}", self.0)
+    }
+}
+
+impl TypePriority {
+    pub const MAX: TypePriority = TypePriority(u8::MAX);
+    pub const APP: TypePriority = TypePriority(3);
+    pub const FORALL: TypePriority = TypePriority(2);
+    pub const FUN: TypePriority = TypePriority(1);
+}
 
 /// Primitive types are the easy cases when unifying types.
 /// They're equal simply if the other type is also the same PrimitiveType variant,
@@ -217,6 +240,17 @@ impl Type {
         }
     }
 
+    pub fn priority(&self) -> TypePriority {
+        use Type::*;
+        match self {
+            Primitive(_) | TypeVariable(_) | UserDefined(_) | Struct(_, _) | Tag(_) => TypePriority::MAX,
+            Function(_) => TypePriority::FUN,
+            TypeApplication(_, _) => TypePriority::APP,
+            Ref { .. } => TypePriority::APP,
+            Effects(_) => unimplemented!("Type::priority for Effects"),
+        }
+    }
+
     /// Pretty-print each type with each typevar substituted for a, b, c, etc.
     pub fn display<'a, 'b>(&self, cache: &'a ModuleCache<'b>) -> typeprinter::TypePrinter<'a, 'b> {
         let typ = GeneralizedType::MonoType(self.clone());
@@ -257,7 +291,7 @@ impl Type {
                 sharedness.traverse_rec(cache, f);
                 mutability.traverse_rec(cache, f);
                 lifetime.traverse_rec(cache, f);
-            }
+            },
             Type::TypeApplication(constructor, args) => {
                 constructor.traverse_rec(cache, f);
                 for arg in args {
@@ -356,7 +390,7 @@ impl Type {
                 let mutable = mutability.approx_to_string();
                 let lifetime = lifetime.approx_to_string();
                 format!("{}{} '{}", mutable, shared, lifetime)
-            }
+            },
             Type::Struct(fields, id) => {
                 let fields = fmap(fields, |(name, typ)| format!("{}: {}", name, typ.approx_to_string()));
                 format!("{{ {}, ..tv{} }}", fields.join(", "), id.0)
@@ -438,6 +472,13 @@ impl GeneralizedType {
         match self {
             GeneralizedType::MonoType(typ) => typ,
             GeneralizedType::PolyType(_, _) => unreachable!(),
+        }
+    }
+
+    pub fn priority(&self) -> TypePriority {
+        match self {
+            GeneralizedType::MonoType(typ) => typ.priority(),
+            GeneralizedType::PolyType(..) => TypePriority::FORALL,
         }
     }
 }

--- a/src/types/typeprinter.rs
+++ b/src/types/typeprinter.rs
@@ -188,11 +188,11 @@ impl<'a, 'b> TypePrinter<'a, 'b> {
 
     fn fmt_function(&self, function: &FunctionType, f: &mut Formatter) -> std::fmt::Result {
         for (i, param) in function.parameters.iter().enumerate() {
-            if TypePriority::FUN >= param.priority() {
+            if TypePriority::FUN >= param.priority(&self.cache) {
                 write!(f, "{}", "(".blue())?;
             }
             self.fmt_type(param, f)?;
-            if TypePriority::FUN >= param.priority() {
+            if TypePriority::FUN >= param.priority(&self.cache) {
                 write!(f, "{}", ")".blue())?;
             }
             write!(f, " ")?;
@@ -214,11 +214,11 @@ impl<'a, 'b> TypePrinter<'a, 'b> {
 
         // No parentheses are necessary if the precedence is the same, because `->` is right associative.
         // i.e. `a -> b -> c` means `a -> (b -> c)`
-        if TypePriority::FUN > function.return_type.priority() {
+        if TypePriority::FUN > function.return_type.priority(&self.cache) {
             write!(f, "{}", "(".blue())?;
         }
         self.fmt_type(function.return_type.as_ref(), f)?;
-        if TypePriority::FUN > function.return_type.priority() {
+        if TypePriority::FUN > function.return_type.priority(&self.cache) {
             write!(f, "{}", ")".blue())?;
         }
 
@@ -256,11 +256,11 @@ impl<'a, 'b> TypePrinter<'a, 'b> {
                 for arg in args {
                     write!(f, " ")?;
                     // `(app f (app a b))` should be represented as `f (a b)`
-                    if TypePriority::APP >= arg.priority() {
+                    if TypePriority::APP >= arg.priority(&self.cache) {
                         write!(f, "{}", "(".blue())?;
                     }
                     self.fmt_type(arg, f)?;
-                    if TypePriority::APP >= arg.priority() {
+                    if TypePriority::APP >= arg.priority(&self.cache) {
                         write!(f, "{}", ")".blue())?;
                     }
                 }
@@ -270,21 +270,21 @@ impl<'a, 'b> TypePrinter<'a, 'b> {
     }
 
     fn fmt_pair(&self, arg1: &Type, arg2: &Type, f: &mut Formatter) -> std::fmt::Result {
-        if TypePriority::PAIR >= arg1.priority() {
+        if TypePriority::PAIR >= arg1.priority(&self.cache) {
             write!(f, "{}", "(".blue())?;
         }
         self.fmt_type(arg1, f)?;
-        if TypePriority::PAIR >= arg1.priority() {
+        if TypePriority::PAIR >= arg1.priority(&self.cache) {
             write!(f, "{}", ")".blue())?;
         }
         write!(f, "{}", ", ".blue())?;
-        // `(,)` is right-associative.
-        // `a, b, .., n, m` means `(a, (b, (.. (n, m)..)))`.
-        if TypePriority::PAIR > arg2.priority() {
+        // Because `(,)` is right-associative, omit parentheses if it has equal priority.
+        // e.g. `a, b, .., n, m` means `(a, (b, (.. (n, m)..)))`.
+        if TypePriority::PAIR > arg2.priority(&self.cache) {
             write!(f, "{}", "(".blue())?;
         }
         self.fmt_type(arg2, f)?;
-        if TypePriority::PAIR > arg2.priority() {
+        if TypePriority::PAIR > arg2.priority(&self.cache) {
             write!(f, "{}", ")".blue())?;
         }
         Ok(())
@@ -336,7 +336,7 @@ impl<'a, 'b> TypePrinter<'a, 'b> {
             self.fmt_type_variable(*typevar, f)?;
         }
         write!(f, "{}", ". ".blue())?;
-        if TypePriority::FORALL > typ.priority() {
+        if TypePriority::FORALL > typ.priority(&self.cache) {
             write!(f, "{}", "(".blue())?;
             self.fmt_type(typ, f)?;
             write!(f, "{}", ")".blue())?;

--- a/src/types/typeprinter.rs
+++ b/src/types/typeprinter.rs
@@ -270,15 +270,24 @@ impl<'a, 'b> TypePrinter<'a, 'b> {
     }
 
     fn fmt_pair(&self, arg1: &Type, arg2: &Type, f: &mut Formatter) -> std::fmt::Result {
-        write!(f, "{}", "(".blue())?;
-
+        if TypePriority::PAIR >= arg1.priority() {
+            write!(f, "{}", "(".blue())?;
+        }
         self.fmt_type(arg1, f)?;
-
+        if TypePriority::PAIR >= arg1.priority() {
+            write!(f, "{}", ")".blue())?;
+        }
         write!(f, "{}", ", ".blue())?;
-
+        // `(,)` is right-associative.
+        // `a, b, .., n, m` means `(a, (b, (.. (n, m)..)))`.
+        if TypePriority::PAIR > arg2.priority() {
+            write!(f, "{}", "(".blue())?;
+        }
         self.fmt_type(arg2, f)?;
-
-        write!(f, "{}", ")".blue())
+        if TypePriority::PAIR > arg2.priority() {
+            write!(f, "{}", ")".blue())?;
+        }
+        Ok(())
     }
 
     fn fmt_polymorphic_numeral(&self, arg: &Type, f: &mut Formatter, kind: &str) -> std::fmt::Result {


### PR DESCRIPTION
refs #202 

Remove redundant parentheses from the type display.
No changes have been made to effect(can) as no decision was made about it.

# Algorithm.

Define the precedence of the binding of each syntactic element as follows.

[primitives > application > forall > pair > fun](https://github.com/eldesh/ante/blob/f51d34710f67fc7c14147138fe00fe70b0e559cd/src/types/mod.rs#L46-L52)

> [!NOTE] 
> The primitives includes generic Int/Float. Then the type `Foo String Int a` means `Foo String (Int a)`


In the display, brackets are added if the priority of the current object is greater than the priority of its sub-element.
The following is pseudo code.

```
fn fmt_A(&self, ...) {
  self.fmt(..)) ; // print current construct A

  if A.priority() > self.part.priority()
    write("("));
  self.fmt_part();
  if A.priority() > self.part.priority()
    write("("));

  self.fmt(..)) ; // print current construct A
}
````


# Result

For completeness_checking.rs the result is as follows:.
`(,)` is right-associative, so the parentheses are removed.

- before.

    ```console
    completeness_checking.an:25:4 error: This pattern of type ((Int a), (Int b)) does not match the type ((Int a), ((Int b)), ((Int c)), (Int d)))) that is being matched on
    | (1, 2) -> 1
    ````

- after

    ````console
    ...
    completeness_checking.an:25:4 error:. This pattern of type Int a, Int b does not match the type Int a, Int b, Int c, Int d that is being matched on
    | (1, 2) -> 1
    ````


For instantiation.rs the following applies.
`(=>)` is also right-associative, so `(a => (b => e))` becomes `a => b => e`.

- before.

    ```console
    add : (forall a b c d e f g h i. ((a - c => e can g) - (a - b => c can g) -> (a => (b => e can g) can h) can i))
    id : (forall a b. (a -> a can b))
    one : (forall a b c d. ((a => b can d) - a -> b can d))
    two1 : (forall a b c. ((b => b can c) - b -> b can c))
    two2 : ((a => a can c) => (a => a can c) can d)
    ```


- after.

    ```console
    add : forall a b c d e f g h i. ((a - c => e can g) - (a - b => c can g) -> a => b => e can g can h can i)
    id : forall a b. (a -> a can b)
    one : forall a b c d. ((a => b can d) - a -> b can d)
    two1 : forall a b c. ((b => b can c) - b -> b can c)
    two2 : (a => a can c) => a => a can c can d
    ```


