### PR TITLE
Move deref typecheck from `get_fields` to `MemberAccess`

### DIFF
--- a/examples/typechecking/field_diagnostics.an
+++ b/examples/typechecking/field_diagnostics.an
@@ -1,0 +1,54 @@
+tuple = (1, 1)
+
+_ = (&&tuple).first
+
+_ = tuple.!first
+_ = tuple.!missing
+
+imm_ref = &tuple
+_ = imm_ref.!first
+_ = imm_ref.!missing
+
+mut_tuple = mut (1, 1)
+
+_ = mut_tuple.&missing
+_ = mut_tuple.!missing
+
+mut_ref = !mut_tuple
+
+_ = mut_ref.&missing
+_ = mut_ref.!missing
+
+_ = (!&tuple).!first
+
+// flags: --check
+// expected stderr:
+// field_diagnostics.an:3:6	error: &shared &shared Int c, Int d has no field 'first' of type { first: b, .. }
+// _ = (&&tuple).first
+// 
+// field_diagnostics.an:5:5	error: Cannot mutably reference `tuple`. It was declared as immutable
+// _ = tuple.!first
+// 
+// field_diagnostics.an:6:5	error: Int a, Int b has no field 'missing' of type { missing: b, .. }
+// _ = tuple.!missing
+// 
+// field_diagnostics.an:9:5	error: Expected a mutable reference but found &shared Int b, Int c instead
+// _ = imm_ref.!first
+// 
+// field_diagnostics.an:10:5	error: &shared Int b, Int c has no field 'missing' of type { missing: b, .. }
+// _ = imm_ref.!missing
+// 
+// field_diagnostics.an:14:5	error: Int a, Int b has no field 'missing' of type { missing: b, .. }
+// _ = mut_tuple.&missing
+// 
+// field_diagnostics.an:15:5	error: Int a, Int b has no field 'missing' of type { missing: b, .. }
+// _ = mut_tuple.!missing
+// 
+// field_diagnostics.an:19:5	error: !shared Int b, Int c has no field 'missing' of type { missing: b, .. }
+// _ = mut_ref.&missing
+// 
+// field_diagnostics.an:20:5	error: !shared Int b, Int c has no field 'missing' of type { missing: b, .. }
+// _ = mut_ref.!missing
+// 
+// field_diagnostics.an:22:6	error: !shared &shared Int c, Int d has no field 'first' of type { first: b, .. }
+// _ = (!&tuple).!first

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -125,7 +125,7 @@ pub enum TypeErrorKind {
     MatchPatternTypeDiffers,
     MatchReturnTypeDiffers,
     DoesNotMatchAnnotatedType,
-    ExpectedStructReference,
+    ExpectedMutable,
 
     // This taking a String is the reason we can't have nice things (Copy)
     NoFieldOfType(/*field name*/ String),
@@ -309,8 +309,8 @@ impl Display for DiagnosticKind {
             DiagnosticKind::TypeError(TypeErrorKind::DoesNotMatchAnnotatedType, actual, expected) => {
                 write!(f, "Expression of type {actual} does not match its annotated type {expected}")
             },
-            DiagnosticKind::TypeError(TypeErrorKind::ExpectedStructReference, actual, _expected) => {
-                write!(f, "Expected a struct reference but found {actual} instead")
+            DiagnosticKind::TypeError(TypeErrorKind::ExpectedMutable, actual, _expected) => {
+                write!(f, "Expected a mutable reference but found {actual} instead")
             },
             DiagnosticKind::TypeError(TypeErrorKind::NoFieldOfType(field_name), actual, expected) => {
                 write!(f, "{actual} has no field '{field_name}' of type {expected}")


### PR DESCRIPTION
I was curious how hard this would be (see https://github.com/jfecher/ante/pull/213#issuecomment-2832021096), and it wasn't actually *that* bad!

This now only allows a single dereference on field access, where previously, multiple dereferences passed typechecking (although this failed later in compilation).

Feel free to not merge this. I don't know what behaviour is desired, and this patch is a little ugly :)

This fixes a typechecking safety hole:

```c
immutable_tuple = (1, 1)
mut_reference = (!&immutable_tuple).!first
mut_reference := 3
```

which now fails with this error:
```
test.an:4:6     error: !shared &shared T has no field 'a' of type { a: b, .. }
a = (!&tuple).!a
```