### PR TITLE
Improve error if ANTE_STDLIB_DIR doesn't exist

### DIFF
--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -85,7 +85,10 @@ fn minicoro_path() -> &'static str {
 
 pub fn stdlib_dir() -> PathBuf {
     match option_env!("ANTE_STDLIB_DIR") {
-        Some(env) => std::fs::canonicalize(env).unwrap(),
+        Some(env) => match std::fs::canonicalize(env) {
+            Ok(env) => env,
+            Err(_) => panic!("Failed to canonicalize stdlib path {env} ; does it exist?"),
+        },
         None => panic!("ANTE_STDLIB_DIR is not set"),
     }
 }


### PR DESCRIPTION
Presently, the build captures the build-time value of ANTE_STDLIB_DIR and handles the case of that not being set, but doesn't handle the case of that pointing to a non-existent directory. I often clone straight to my downloads folder (which is mounted as an ephemeral tmpfs) to test things out, which meant that, after a reboot, `ante` no longer ran as the stdlib path didn't exist and it gave a rather cryptic error about a file/directory being missing without specifying which path. This just patches it to also handle canonicalization failing by giving a more helpful error message.

Goldentests seem to only be failing because my install is outputting an extra `note: run with RUST_BACKTRACE=1 environment variable to display a backtrace` in stderr that the tests don't expect, but that seems like a separate thing; ANTE_STDLIB_DIR isn't mentioned in any tests, so I'm fairly confident it's just a me problem.