### PR TITLE
Fix next_line buffer growth and add infile iteration example

### DIFF
--- a/examples/codegen/infile_iter.an
+++ b/examples/codegen/infile_iter.an
@@ -1,0 +1,8 @@
+main =
+    infile = open_infile "tests/fixtures/infile_iter.txt"
+    iter infile print
+
+// args: --delete-binary
+// expected stdout:
+// alpha
+// beta

--- a/stdlib/prelude.an
+++ b/stdlib/prelude.an
@@ -621,29 +621,31 @@ next_char (f: InFile) : Char =
 next_line (f: InFile) : String =
     if eof f then return ""
 
-    mut capacity = 32
-    mut cstr = malloc @capacity
+    capacity = 32
+    cstr: Ptr Char = malloc capacity
 
-    len = loop (len = 0) ->
-        next = next_char f
-        if next < 0 then return len
+    (result_cstr, len) = loop (capacity: Usz) (cstr: Ptr Char) (len = 0) ->
+        next = fgetc f
+        if next < 0 then return (cstr, len)
         c: Char = cast next
+        mut next_capacity = capacity
+        mut next_cstr = cstr
 
         //Flag feof if eof occurs after terminating newline
         if c == '\n' then
-            peek = next_char f
+            peek = fgetc f
             if peek >= 0 then ungetc (cast peek) f
-            return len
+            return (cstr, len)
 
-        if len + 1 >= @capacity then
-            capacity := @capacity * 2
-            cstr := realloc (@cstr) (@capacity)
+        if len + 1 >= capacity then
+            next_capacity := capacity * 2
+            next_cstr := realloc (cstr) (next_capacity)
 
-        array_insert (@cstr) len c
-        recur (len + 1)
+        array_insert (next_cstr) len c
+        recur next_capacity next_cstr (len + 1)
 
-    array_insert (@cstr) len '\0'
-    String (@cstr) len
+    array_insert (result_cstr) len '\0'
+    String (result_cstr) len
 
 // Read a line from stdin, ending with (and not including) a terminating '\n'
 read_line () : String =

--- a/tests/fixtures/infile_iter.txt
+++ b/tests/fixtures/infile_iter.txt
@@ -1,0 +1,2 @@
+alpha
+beta


### PR DESCRIPTION
This PR fixes an issue I noticed in stdlib/prelude.an, where next_line did not seem to behave correctly.

To make the problem explicit, I added an example that triggers an error under the current implementation in `examples/codegen/infile_iter.an`
It produces the following error message:
```
prelude.an:625:24	error: Expected argument of type &c, but found Int a
    mut cstr = malloc @capacity

prelude.an:629:19	error: Expected argument of type Char, but found Int a
        if next < 0 then return len

prelude.an:635:24	error: Expected argument of type Char, but found Int a
            if peek >= 0 then ungetc (cast peek) f

prelude.an:638:24	error: Expected argument of type &c, but found Int a
        if len + 1 >= @capacity then

prelude.an:639:26	error: Expected argument of type &c, but found Int a
            capacity := @capacity * 2

prelude.an:639:13	error: Cannot mutably reference `capacity`. It was declared as immutable
            capacity := @capacity * 2

prelude.an:640:31	error: Expected argument of type &c, but found Ptr a
            cstr := realloc (@cstr) (@capacity)

prelude.an:640:39	error: Expected argument of type &c, but found Int a
            cstr := realloc (@cstr) (@capacity)

prelude.an:640:13	error: Cannot mutably reference `cstr`. It was declared as immutable
            cstr := realloc (@cstr) (@capacity)

prelude.an:642:24	error: Expected argument of type &c, but found Ptr a
        array_insert (@cstr) len c

prelude.an:645:20	error: Expected argument of type &c, but found Ptr a
    array_insert (@cstr) len '\0'

prelude.an:646:14	error: Expected argument of type &c, but found Ptr a
    String (@cstr) len

prelude.an:629:12	error: No impl found for Cmp Char
        if next < 0 then return len

prelude.an:635:16	error: No impl found for Cmp Char
            if peek >= 0 then ungetc (cast peek) f
```

I made this fix against the `master` branch because I wanted to properly verify the behavior and confirm that the issue was indeed resolved in the current implementation.

If this issue has already been fixed in the `incremental` branch, I apologize for the duplicate work.

If there is a preferred approach for migrating this change to `incremental`, or if any adjustments are needed to align with the current direction of development, please let me know and I will be happy to