### PR TITLE
Have the CLI properly error with no source files

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,7 +13,7 @@ pub struct Completions {
 #[command(author, version, about, long_about = None)]
 pub struct Cli {
     /// Path to the source files
-    #[arg(value_hint=ValueHint::FilePath)]
+    #[arg(value_hint = ValueHint::FilePath, required = true)]
     pub files: Vec<PathBuf>,
 
     /// Print out the input file annotated with inferred lifetimes of heap allocations


### PR DESCRIPTION
Without this it was successfully "compiling" the empty program and then failing to run it because it has no main function.