### PR TITLE
fix nix flake

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "minicoro"]
-	path = minicoro
-	url = https://github.com/jfecher/minicoro
 [submodule "aminicoro"]
 	path = aminicoro
 	url = https://github.com/jfecher/minicoro


### PR DESCRIPTION
Removed leftover git module which caused Nix to choke when trying to compile `ante-minicoro` package. Tests seemed good on my machine and I could compile a hello world (plus considering its removing 3 lines it should be fine)