### PR TITLE
Add `ante add` command for git dependencies

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -12,6 +12,12 @@ pub struct Completions {
 pub enum Commands {
     Build,
     Run,
+    /// Clone a git dependency into this project's dependency directory
+    Add {
+        /// Git repository URL to add as a dependency
+        #[arg(value_hint = ValueHint::Url)]
+        dep_url: String,
+    },
 }
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]

--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -1,0 +1,38 @@
+use std::process::Command;
+
+use colored::Colorize;
+
+use crate::{find_files::find_nearest_project_root, manifest::MANIFEST_FILE_NAME};
+
+pub const DEPENDENCIES_DIR_NAME: &str = "deps";
+
+/// Add a git dependency to the current Ante project by cloning it into the dependencies directory.
+pub fn add_git_dependency(dep_url: &str) {
+    let Some(project_root) = find_nearest_project_root() else {
+        eprintln!(
+            "{}: could not find {MANIFEST_FILE_NAME} in the current directory or any parent directory",
+            "error".red(),
+        );
+        std::process::exit(1);
+    };
+
+    let deps_dir = project_root.join(DEPENDENCIES_DIR_NAME);
+    if let Err(error) = std::fs::create_dir_all(&deps_dir) {
+        eprintln!("{}: failed to create `{}`:\n{error}", "error".red(), deps_dir.display());
+        std::process::exit(1);
+    }
+
+    let status = Command::new("git").arg("clone").arg(dep_url).current_dir(&deps_dir).status();
+    match status {
+        Ok(status) if status.success() => (),
+        Ok(status) => {
+            let code = status.code().map_or_else(|| "terminated by signal".to_string(), |code| code.to_string());
+            eprintln!("{}: git clone failed with exit status {code}", "error".red());
+            std::process::exit(1);
+        },
+        Err(error) => {
+            eprintln!("{}: failed to run git clone:\n{error}", "error".red());
+            std::process::exit(1);
+        },
+    }
+}

--- a/src/files.rs
+++ b/src/files.rs
@@ -29,7 +29,7 @@ pub fn make_compiler(source_files: &[PathBuf], incremental: bool) -> (Db, Option
     // Use the discovered project root when building a project.
     // Fall back to the current directory for explicit file compilation.
     let local_crate_root =
-        crate::find_files::find_project_root().unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
+        crate::find_files::find_nearest_project_root().unwrap_or_else(|| std::env::current_dir().unwrap_or_default());
     crate::find_files::populate_crates_and_files(&mut compiler, &local_crate_root, source_files);
     (compiler, metadata_file)
 }

--- a/src/find_files.rs
+++ b/src/find_files.rs
@@ -8,7 +8,12 @@ use clap::builder::OsStr;
 use rustc_hash::FxHashSet;
 
 use crate::{
-    files::read_file, incremental::{Crate, Db, GetCrateGraph, SourceFile}, manifest::Manifest, name_resolution::namespace::{CrateId, SourceFileId}, paths::stdlib_path
+    dependencies::DEPENDENCIES_DIR_NAME,
+    files::read_file,
+    incremental::{Crate, Db, GetCrateGraph, SourceFile},
+    manifest::{MANIFEST_FILE_NAME, Manifest},
+    name_resolution::namespace::{CrateId, SourceFileId},
+    paths::stdlib_path,
 };
 
 pub type CrateGraph = BTreeMap<CrateId, Crate>;
@@ -16,23 +21,28 @@ pub type CrateGraph = BTreeMap<CrateId, Crate>;
 /// Default name of the local crate when its `ante.toml` has no `name` field.
 pub const DEFAULT_LOCAL_CRATE_NAME: &str = "Local";
 
-pub fn find_project_root() -> Option<PathBuf> {
-    let mut current_dir = std::env::current_dir().ok()?;
+/// Default name of the src folder.
+pub(crate) const SRC_FOLDER: &str = "src";
+pub(crate) const MAIN_FILE: &str = "main.an";
+
+/// Search the current directory and its ancestors for an Ante manifest.
+pub fn find_nearest_project_root() -> Option<PathBuf> {
+    let mut dir = std::env::current_dir().ok()?;
 
     loop {
-        if current_dir.join("ante.toml").exists() {
-            return Some(current_dir);
+        if dir.join(MANIFEST_FILE_NAME).is_file() {
+            return Some(dir);
         }
 
-        if !current_dir.pop() {
+        if !dir.pop() {
             return None;
         }
     }
 }
 
 pub fn find_project_main_file() -> Option<PathBuf> {
-    let root = find_project_root()?;
-    Some(root.join("src").join("main.an"))
+    let root = find_nearest_project_root()?;
+    Some(root.join(SRC_FOLDER).join(MAIN_FILE))
 }
 
 // TODO:
@@ -110,7 +120,7 @@ fn set_crate_inputs(compiler: &mut Db, crates: CrateGraph) {
 fn add_source_files_of_crate(compiler: &mut Db, crates: &mut CrateGraph, crate_id: CrateId) {
     let crate_root = crates[&crate_id].path.clone();
     let mut src_folder = crate_root.clone();
-    src_folder.push("src");
+    src_folder.push(SRC_FOLDER);
 
     let mut remaining = vec![src_folder.clone()];
     let mut source_files = BTreeMap::new();
@@ -204,36 +214,35 @@ fn read_file_data(file: PathBuf) -> SourceFile {
 /// It never checks for duplicates.
 fn find_crate_dependencies(crates: &mut CrateGraph, crate_id: CrateId) -> Vec<CrateId> {
     let mut deps_folder = crates[&crate_id].path.clone();
-    deps_folder.push("deps");
+    deps_folder.push(DEPENDENCIES_DIR_NAME);
 
     // Every crate currently depends on the stdlib
     let mut dependencies = vec![CrateId::STDLIB];
-    let mut remaining = vec![deps_folder];
 
-    // Push every crate in the `deps` folder as a new crate
-    while let Some(deps_folder) = remaining.pop() {
-        // We should error in the future when failing to read a directory but for now we want to
-        // allow either the local crate or the stdlib to not be present and still compile when
-        // we're only working on a single source file. We may want to separate the compile mode
-        // more explicitly in the CLI in the future.
-        let Ok(deps_folder) = deps_folder.read_dir() else {
-            continue;
-        };
+    // We should error in the future when failing to read a directory but for now we want to
+    // allow either the local crate or the stdlib to not be present and still compile when
+    // we're only working on a single source file. We may want to separate the compile mode
+    // more explicitly in the CLI in the future.
+    let Ok(deps_folder) = deps_folder.read_dir() else {
+        return dependencies;
+    };
 
-        for dependency in deps_folder.flatten() {
-            let path = dependency.path();
-            if path.is_dir() {
-                let manifest = Manifest::read(&path).unwrap_or_default();
-                let fallback_name = path.file_name().unwrap().to_string_lossy().into_owned();
+    // Push every crate in the dependencies directory as a new direct dependency.
+    // Transitive dependencies are discovered by `populate_crates_and_files` when these crates
+    // are later processed from its stack.
+    for dependency in deps_folder.flatten() {
+        let path = dependency.path();
+        if path.is_dir() {
+            let manifest = Manifest::read(&path).unwrap_or_default();
+            let fallback_name = path.file_name().unwrap().to_string_lossy().into_owned();
 
-                // `apply` overrides the fallback directory name with the manifest name if present.
-                let mut dependency = Crate::new(fallback_name, path);
-                manifest.apply(&mut dependency);
+            // `apply` overrides the fallback directory name with the manifest name if present.
+            let mut dependency = Crate::new(fallback_name, path);
+            manifest.apply(&mut dependency);
 
-                let id = new_crate_id(crates, &dependency.name, 0);
-                dependencies.push(id);
-                crates.insert(id, dependency);
-            }
+            let id = new_crate_id(crates, &dependency.name, 0);
+            dependencies.push(id);
+            crates.insert(id, dependency);
         }
     }
 
@@ -251,4 +260,96 @@ fn new_crate_id(crates: &CrateGraph, name: &String, version: u32) -> CrateId {
         }
     }
     unreachable!("We have somehow had i32::MAX hash collisions")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestDir {
+        path: PathBuf,
+    }
+
+    impl TestDir {
+        fn new(name: &str) -> Self {
+            let mut path = std::env::temp_dir();
+            path.push(format!("ante-{name}-{}-{}", std::process::id(), crate::parser::ids::hash(name)));
+            let _ = std::fs::remove_dir_all(&path);
+            std::fs::create_dir_all(&path).unwrap();
+            TestDir { path }
+        }
+
+        fn create_dependency(&self, dirname: &str, manifest_name: Option<&str>) -> PathBuf {
+            let path = self.path.join(DEPENDENCIES_DIR_NAME).join(dirname);
+            std::fs::create_dir_all(&path).unwrap();
+            if let Some(name) = manifest_name {
+                std::fs::write(path.join(MANIFEST_FILE_NAME), format!("name = \"{name}\"\n")).unwrap();
+            }
+            path
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+
+    fn local_crate_graph(path: PathBuf) -> CrateGraph {
+        let mut crates = CrateGraph::default();
+        crates.insert(CrateId::LOCAL, Crate::new(DEFAULT_LOCAL_CRATE_NAME.to_string(), path));
+        crates
+    }
+
+    #[test]
+    fn missing_dependencies_directory_only_depends_on_stdlib() {
+        let dir = TestDir::new("missing-deps");
+        let mut crates = local_crate_graph(dir.path.clone());
+
+        let dependencies = find_crate_dependencies(&mut crates, CrateId::LOCAL);
+
+        assert_eq!(dependencies, vec![CrateId::STDLIB]);
+        assert_eq!(crates.len(), 1);
+    }
+
+    #[test]
+    fn discovers_direct_dependencies_from_dependencies_directory() {
+        let dir = TestDir::new("direct-deps");
+        let alpha_path = dir.create_dependency("alpha", Some("Alpha"));
+        let beta_path = dir.create_dependency("beta", None);
+        let mut crates = local_crate_graph(dir.path.clone());
+
+        let dependencies = find_crate_dependencies(&mut crates, CrateId::LOCAL);
+
+        assert_eq!(dependencies.len(), 3);
+        assert_eq!(dependencies[0], CrateId::STDLIB);
+
+        let dependency_crates = dependencies
+            .iter()
+            .skip(1)
+            .map(|id| crates.get(id).unwrap())
+            .map(|crate_| (crate_.name.as_str(), crate_.path.as_path()))
+            .collect::<BTreeMap<_, _>>();
+
+        assert_eq!(dependency_crates["Alpha"], alpha_path.as_path());
+        assert_eq!(dependency_crates["beta"], beta_path.as_path());
+    }
+
+    #[test]
+    fn transitive_dependencies_are_not_returned_as_direct_dependencies() {
+        let dir = TestDir::new("transitive-deps");
+        let alpha_path = dir.create_dependency("alpha", Some("Alpha"));
+        let nested_path = alpha_path.join(DEPENDENCIES_DIR_NAME).join("nested");
+        std::fs::create_dir_all(&nested_path).unwrap();
+        std::fs::write(nested_path.join(MANIFEST_FILE_NAME), "name = \"Nested\"\n").unwrap();
+        let mut crates = local_crate_graph(dir.path.clone());
+
+        let dependencies = find_crate_dependencies(&mut crates, CrateId::LOCAL);
+
+        assert_eq!(dependencies.len(), 2);
+        let alpha = crates.get(&dependencies[1]).unwrap();
+        assert_eq!(alpha.name, "Alpha");
+        assert_eq!(alpha.path, alpha_path);
+        assert!(!crates.values().any(|crate_| crate_.name == "Nested"));
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(mismatched_lifetime_syntaxes)]
 
 mod definition_collection;
+pub mod dependencies;
 pub mod find_files;
 pub mod lexer;
 pub mod name_resolution;

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,6 +61,7 @@ use crate::{
 };
 
 mod codegen;
+mod dependencies;
 mod definition_collection;
 mod find_files;
 mod lexer;
@@ -90,17 +91,23 @@ fn main() {
         let name = cmd.get_name().to_string();
         clap_complete::generate(shell_completion, &mut cmd, name, &mut std::io::stdout());
     } else {
-        compile(Cli::parse())
+        let args = Cli::parse();
+        if let Some(Commands::Add { dep_url }) = &args.command {
+            dependencies::add_git_dependency(dep_url);
+        } else {
+            compile(args)
+        }
     }
 }
 
 fn compile(args: Cli) {
     let (run, files, is_project) = match &args.command {
-        Some(cmd) => (
+        Some(cmd @ (Commands::Build | Commands::Run)) => (
             matches!(cmd, Commands::Run),
             crate::find_files::find_project_main_file().map(|path| vec![path]).unwrap_or_default(),
             true,
         ),
+        Some(Commands::Add { .. }) => unreachable!("add commands are handled before compiling"),
         None => (!args.build, args.files.clone(), false),
     };
     let (mut compiler, metadata_file) = make_compiler(&files, args.incremental);

--- a/src/main.rs
+++ b/src/main.rs
@@ -463,7 +463,12 @@ fn check_and_select_main(
 /// Run the binary then optionally delete it.
 fn run_binary(program_name: &str, delete_binary: bool) {
     let binary_path = binary_name(program_name);
-    Command::new(&binary_path).spawn().unwrap().wait().unwrap();
+    let run_path = if binary_path.components().count() == 1 {
+        Path::new(".").join(&binary_path)
+    } else {
+        binary_path.clone()
+    };
+    Command::new(&run_path).spawn().unwrap().wait().unwrap();
     if delete_binary {
         std::fs::remove_file(binary_path).unwrap();
     }
@@ -471,7 +476,7 @@ fn run_binary(program_name: &str, delete_binary: bool) {
 
 /// Return the default name of the program given the source files.
 fn files_to_program_name(files: &[PathBuf]) -> String {
-    let name = files.first().map_or_else(|| "a.out".into(), |file| file.with_extension(""));
+    let name = files.first().map_or_else(|| "a".into(), |file| file.with_extension(""));
     name.to_string_lossy().into_owned()
 }
 
@@ -480,7 +485,7 @@ fn project_program_name(compiler: &mut Db) -> String {
     let crates = GetCrateGraph.get(compiler);
     let name = &crates[&CrateId::LOCAL].name;
     if name == crate::find_files::DEFAULT_LOCAL_CRATE_NAME {
-        "a.out".to_string()
+        "a".to_string()
     } else {
         name.clone()
     }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -2,6 +2,8 @@ use std::path::Path;
 
 use crate::incremental::Crate;
 
+pub const MANIFEST_FILE_NAME: &str = "ante.toml";
+
 #[derive(serde::Deserialize, Default)]
 pub struct Manifest {
     pub name: Option<String>,
@@ -18,7 +20,7 @@ pub struct Manifest {
 impl Manifest {
     /// Read and parse the `ante.toml` manifest in the given crate root directory, if present.
     pub fn read(root: &Path) -> Option<Manifest> {
-        let contents = std::fs::read_to_string(root.join("ante.toml")).ok()?;
+        let contents = std::fs::read_to_string(root.join(MANIFEST_FILE_NAME)).ok()?;
         toml::from_str(&contents).ok()
     }
 

--- a/src/name_resolution/mod.rs
+++ b/src/name_resolution/mod.rs
@@ -12,6 +12,7 @@ pub mod namespace;
 
 use crate::{
     diagnostics::{Diagnostic, Location},
+    find_files::SRC_FOLDER,
     incremental::{
         self, DbHandle, ExportedTypes, GetCrateGraph, GetItem, Resolve, VisibleDefinitions, VisibleDefinitionsResult,
     },
@@ -304,7 +305,7 @@ impl<'local, 'inner> Resolver<'local, 'inner> {
             }
 
             // Fall back to absolute path (crate_root/src/Vec.an)
-            let absolute = crate_.path.join("src").join(&module_file);
+            let absolute = crate_.path.join(SRC_FOLDER).join(&module_file);
             if let Some(id) = crate_.source_files.get(&absolute).copied() {
                 return Some(Namespace::Module(id));
             }

--- a/src/name_resolution/namespace.rs
+++ b/src/name_resolution/namespace.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{parser::ids::TopLevelId, paths::prelude_path_relative_to_stdlib_source_folder};
+use crate::{find_files::SRC_FOLDER, parser::ids::TopLevelId, paths::prelude_path_relative_to_stdlib_source_folder};
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub(super) enum Namespace {
@@ -56,7 +56,7 @@ impl SourceFileId {
     /// - Remove a `src` directory prefix
     pub fn normalize_path<'a>(root: &'a std::path::Path, path: &'a std::path::Path) -> &'a std::path::Path {
         let relative = path.strip_prefix(root).unwrap_or(path);
-        relative.strip_prefix("src").unwrap_or(relative)
+        relative.strip_prefix(SRC_FOLDER).unwrap_or(relative)
     }
 
     pub fn prelude() -> SourceFileId {


### PR DESCRIPTION
Hello! I thought I'd have a crack at tackling https://github.com/jfecher/ante/issues/235 . `ante add` specifically
This PR implements the most naive approach - that is simply cloning the dependency via running Git.

Theres certain more we could iterate on here with dependency handling via `ante.toml`. Further "sanity" checking of dependencies at "ante add" time instead of build time (e.g. requiring ante.toml file in dependencies - or even all ante projects?). And of course eventually going the full monty and adding a registry/versioned dependencies/checksums etc. But since this is my first contribution I wanted to keep the scope small and useful, but I'd love to iterate on some of these things together.

Theres also a second commit - I fixed ante run for projects without a manifest name: the compiler was deriving the fallback output path inconsistently (a.out became a) and then trying to spawn the bare filename. It now uses a consistently and runs local binaries via ./a.

# Testing

For testing I made the classic is-even dependency - https://github.com/rupert648/ante-is-even
And ran through the workflow of adding it to a mini CLI project (P.S. am I being dumb and missing a parse_i32 in stdlib?)
```
import Std.Env
import Std.Vec
import Std.Stream.stream_fn
import Std.Char.is_digit
import IsEven.Lib.is_even

parse_i32 (s: String): Maybe I32 =
    if s.length == 0 then return Maybe.None

    loop (i = 0usz) (value = 0) ->
        if i == Usz s.length then return Maybe.Some value

        c = s.data.[i]
        if not is_digit c then return Maybe.None

        recur (i + 1) (value * 10 + (I32 c - I32 '0'))

main () =
    args = Vec.of Env.args
    if args.len != 2 then
        println "usage: ante-add-test <number>"
        return ()

    match parse_i32 args.data.[1]
    | None -> println "error: expected a non-negative integer"
    | Some n ->
        if is_even n then
            println ((cast n: String) ++ " is even")
        else
            println ((cast n: String) ++ " is odd")
```

Then running/adding dependency
```sh
~/Documents/personal/ante-add-test ⌚ 17:16:46
$ /Users/rupert/Documents/personal/ante/target/debug/ante build
/Users/rupert/Documents/personal/ante-add-test/src/main.an:5:8
4 | import Std.Char.is_digit
5 | import IsEven.Lib.is_even   // error: Could not find module `Lib` in crate `IsEven`

/Users/rupert/Documents/personal/ante-add-test/src/main.an:27:12
26 |     | Some n ->
27 |         if is_even n then  // error: `is_even` not found in scope
28 |             println ((cast n: String) ++ " is even")

Found 2 errors and 0 warnings

~/Documents/personal/ante-add-test ⌚ 17:16:48
$ /Users/rupert/Documents/personal/ante/target/debug/ante add git@github.com:rupert648/ante-is-even.git
Cloning into 'ante-is-even'...
remote: Enumerating objects: 8, done.
remote: Counting objects: 100% (8/8), done.
remote: Compressing objects: 100% (5/5), done.
remote: Total 8 (delta 0), reused 8 (delta 0), pack-reused 0 (from 0)
Receiving objects: 100% (8/8), done.

~/Documents/personal/ante-add-test ⌚ 17:16:55
$ /Users/rupert/Documents/personal/ante/target/debug/ante build

~/Documents/personal/ante-add-test ⌚ 17:17:03
$ ./a hello
error: expected a non-negative integer

~/Documents/personal/ante-add-test ⌚ 17:17:11
$ ./a 42
42 is even

~/
```
