### PR TITLE
Use Fail ability for checked_i32 Math and add basic i32 string parsing

### DIFF
--- a/examples/codegen/stdlib-tests/math.an
+++ b/examples/codegen/stdlib-tests/math.an
@@ -1,6 +1,7 @@
 import Std.Math.sqrt, pow, floor, ceil, abs
 import Std.Math.overflowing_add_i32, overflowing_sub_i32, overflowing_mul_i32
 import Std.Math.checked_add_i32, checked_sub_i32, checked_mul_i32
+import Std.Fail.try
 
 main () =
     println <| sqrt 16.0
@@ -10,13 +11,13 @@ main () =
     println <| abs (0.0 - 7.5)
     println <| abs 5
     println <| abs (0 - 12345)
-    println <| checked_add_i32 2_147_483_647 1
-    println <| checked_add_i32 40 2
-    println <| checked_sub_i32 -2_147_483_648 1
-    println <| checked_sub_i32 40 2
-    println <| checked_mul_i32 50_000 50_000
-    println <| checked_mul_i32 -2_147_483_648 -1
-    println <| checked_mul_i32 -12 3
+    println (try do checked_add_i32 2_147_483_647 1)
+    println (try do checked_add_i32 40 2)
+    println (try do checked_sub_i32 -2_147_483_648 1)
+    println (try do checked_sub_i32 40 2)
+    println (try do checked_mul_i32 50_000 50_000)
+    println (try do checked_mul_i32 -2_147_483_648 -1)
+    println (try do checked_mul_i32 -12 3)
     println <| overflowing_add_i32 40 2
     println <| overflowing_add_i32 2_147_483_647 1
     println <| overflowing_sub_i32 40 2

--- a/examples/codegen/stdlib-tests/string.an
+++ b/examples/codegen/stdlib-tests/string.an
@@ -1,6 +1,7 @@
-import Std.String.bytes, chars, substr, string_of, join, split, reverse
+import Std.String.bytes, chars, substr, string_of, join, split, reverse, parse_i32
 import Std.Stream.iter, intersperse, stream_fn, Emit, emit
 import Std.String.starts_with, ends_with, contains, trim, trim_start, trim_end
+import Std.Fail.try
 
 main () =
     // bytes & chars:
@@ -26,6 +27,7 @@ main () =
     // join over an interspersed stream → single String "a, b, c"
     println (intersperse abc_stream ", " |> join)
     test_predicates ()
+    test_parse ()
 
 abc_stream {Emit String}: Unit =
     emit "a"
@@ -47,6 +49,36 @@ test_predicates () =
     println ("[" ++ trim_end "  hi  " ++ "]")
     println ("[" ++ trim "   " ++ "]")
     println ("[" ++ trim "no-trim" ++ "]")
+
+test_parse () =
+    println (try do parse_i32 "0")
+    println (try do parse_i32 "-0")
+    println (try do parse_i32 "+0")
+    println (try do parse_i32 "000123")
+    println (try do parse_i32 "12345")
+    println (try do parse_i32 "-42")
+    println (try do parse_i32 "+7")
+    println (try do parse_i32 "+123")
+    println (try do parse_i32 "")
+    println (try do parse_i32 "-")
+    println (try do parse_i32 "+")
+    println (try do parse_i32 "--")
+    println (try do parse_i32 "+-")
+    println (try do parse_i32 "-+")
+    println (try do parse_i32 "++")
+    println (try do parse_i32 "12x")
+    println (try do parse_i32 "x12")
+    println (try do parse_i32 "1_000")
+    println (try do parse_i32 " 1")
+    println (try do parse_i32 "1 ")
+    println (try do parse_i32 "0xff")
+    println (try do parse_i32 "2147483647")
+    println (try do parse_i32 "2147483648")
+    println (try do parse_i32 "999999999999999999999999999")
+    println (try do parse_i32 "-2147483647")
+    println (try do parse_i32 "-2147483648")
+    println (try do parse_i32 "-2147483649")
+    println (try do parse_i32 "-999999999999999999999999999")
 
 // args: --delete-binary --no-color
 // expected stdout:
@@ -79,3 +111,31 @@ test_predicates () =
 // [  hi]
 // []
 // [no-trim]
+// Some 0
+// Some 0
+// Some 0
+// Some 123
+// Some 12345
+// Some -42
+// Some 7
+// Some 123
+// None
+// None
+// None
+// None
+// None
+// None
+// None
+// None
+// None
+// None
+// None
+// None
+// None
+// Some 2147483647
+// None
+// None
+// Some -2147483647
+// Some -2_147_483_648
+// None
+// None

--- a/stdlib/src/Math.an
+++ b/stdlib/src/Math.an
@@ -1,3 +1,5 @@
+import Std.Fail.Fail, fail_if
+
 export sqrt, sqrtf, cbrt, pow, powf, exp, log, log2, log10,
     sin, cos, tan, asin, acos, atan, atan2,
     floor, ceil, round, trunc, fmod, hypot,
@@ -44,20 +46,23 @@ abs (x: t) {n: Num t} {Copy t}: t =
     (-) = n.sub.(-)
     if x < n.zero then n.zero - x else x
 
-/// Add two I32 values, returning `None` on overflow.
-checked_add_i32 (x: I32) (y: I32): Maybe I32 =
+/// Add two I32 values, failing on overflow.
+checked_add_i32 (x: I32) (y: I32) {Fail}: I32 =
     result, overflowed = overflowing_add_i32 x y
-    if overflowed then None else Some result
+    fail_if overflowed
+    result
 
-/// Subtract two I32 values, returning `None` on overflow.
-checked_sub_i32 (x: I32) (y: I32): Maybe I32 =
+/// Subtract two I32 values, failing on overflow.
+checked_sub_i32 (x: I32) (y: I32) {Fail}: I32 =
     result, overflowed = overflowing_sub_i32 x y
-    if overflowed then None else Some result
+    fail_if overflowed
+    result
 
-/// Multiply two I32 values, returning `None` on overflow.
-checked_mul_i32 (x: I32) (y: I32): Maybe I32 =
+/// Multiply two I32 values, failing on overflow.
+checked_mul_i32 (x: I32) (y: I32) {Fail}: I32 =
     result, overflowed = overflowing_mul_i32 x y
-    if overflowed then None else Some result
+    fail_if overflowed
+    result
 
 /// Add two I32 values, returning the wrapped result and whether overflow occurred.
 overflowing_add_i32 (x: I32) (y: I32): (I32, Bool) =

--- a/stdlib/src/String.an
+++ b/stdlib/src/String.an
@@ -2,7 +2,9 @@ import Std.Vec
 import Std.C.malloc, memcpy, memcmp
 import Std.Stream.Emit, emit, Stream, foldl, map, stream_fn
 import Std.Vec.Vec
-import Std.Char.is_whitespace
+import Std.Char.is_whitespace, to_digit
+import Std.Math.checked_add_i32, checked_sub_i32, checked_mul_i32
+import Std.Fail.Fail, fail, fail_if
 
 // TODO: All functions in this file should be a method on String, but String isn't defined in this file
 
@@ -139,3 +141,40 @@ trim_end (s: String): String =
 /// Return a substring with both leading and trailing ASCII whitespace removed.
 trim (s: String): String =
     trim_start s |> trim_end
+
+/// Parse a base-10 I32 from a string.
+///
+/// Fails for empty strings, sign-only strings, non-digits, or overflow.
+parse_i32 (s: String) {Fail}: I32 =
+    len = Usz s.length
+    fail_if (len == 0)
+
+    var i = 0usz
+    var negative = false
+
+    first: Char = s.data.[0]
+    if first == '-' then
+        negative := true
+        i += 1
+    else if first == '+' then
+        i += 1
+
+    fail_if (i == len)
+
+    var result = 0i32
+
+    while i < len do
+        digit = match to_digit s.data.[i]
+        | Some d -> I32 d
+        | None -> fail ()
+
+        result := checked_mul_i32 result 10
+
+        if negative then
+            result := checked_sub_i32 result digit
+        else
+            result := checked_add_i32 result digit
+
+        i += 1
+
+    result


### PR DESCRIPTION
Switches the `checked_*_i32` functions to use `{Fail}` and updates call points. Note for now I just switched the golden callsites to do something like
```
println (try (fn f -> checked_add_i32 2_147_483_647 1 {f}) : Maybe I32)
```
so then we can use Maybe and get the same output, but we could prob add a stdlib.test assertion helper here (which just does the same thing).

The second commit adds string parsing for i32s and some tests. I've updated the [followup](https://github.com/rupert648/ante/pull/2) to implement this for all integer types and implement `TryCast` as we discussed.