### PR TITLE
Add TryCast impls for integer string parsing

### DIFF
--- a/examples/codegen/stdlib-tests/math.an
+++ b/examples/codegen/stdlib-tests/math.an
@@ -1,7 +1,14 @@
 import Std.Math.sqrt, pow, floor, ceil, abs
-import Std.Math.overflowing_add_i32, overflowing_sub_i32, overflowing_mul_i32
-import Std.Math.checked_add_i32, checked_sub_i32, checked_mul_i32
+import Std.Math.checked_add, checked_sub, checked_mul, checked_num_i32
+import Std.Math.checked_add_i8, checked_add_i16, checked_add_i32, checked_add_i64, checked_add_isz
+import Std.Math.checked_add_u8, checked_add_u16, checked_add_u32, checked_add_u64, checked_add_usz
+import Std.Math.checked_sub_i8, checked_sub_i16, checked_sub_i32, checked_sub_i64, checked_sub_isz
+import Std.Math.checked_sub_u8, checked_sub_u16, checked_sub_u32, checked_sub_u64, checked_sub_usz
+import Std.Math.checked_mul_i8, checked_mul_i16, checked_mul_i32, checked_mul_i64, checked_mul_isz
+import Std.Math.checked_mul_u8, checked_mul_u16, checked_mul_u32, checked_mul_u64, checked_mul_usz
+import Std.Math.checked_num_i8, checked_num_u8, checked_num_i64, checked_num_u64
 import Std.Fail.try
+
 
 main () =
     println <| sqrt 16.0
@@ -13,17 +20,54 @@ main () =
     println <| abs (0 - 12345)
     println (try do checked_add_i32 2_147_483_647 1)
     println (try do checked_add_i32 40 2)
+    println (try do checked_add_i8 127i8 1i8)
+    println (try do checked_add_i16 32_767i16 1i16)
+    println (try do checked_add_i64 9_223_372_036_854_775_807i64 1i64)
+    println (try do checked_add_isz 9_223_372_036_854_775_807isz 1isz)
+    println (try do checked_add_u8 255u8 1u8)
+    println (try do checked_add_u16 65_535u16 1u16)
+    println (try do checked_add_u32 4_294_967_295u32 1u32)
+    println (try do checked_add_u64 18_446_744_073_709_551_615u64 1u64)
+    println (try do checked_add_usz 18_446_744_073_709_551_615usz 1usz)
     println (try do checked_sub_i32 -2_147_483_648 1)
     println (try do checked_sub_i32 40 2)
+    println (try do checked_sub_i8 -128i8 1i8)
+    println (try do checked_sub_i16 -32_768i16 1i16)
+    println (try do checked_sub_i64 -9_223_372_036_854_775_808i64 1i64)
+    println (try do checked_sub_isz -9_223_372_036_854_775_808isz 1isz)
+    println (try do checked_sub_u8 0u8 1u8)
+    println (try do checked_sub_u16 0u16 1u16)
+    println (try do checked_sub_u32 0u32 1u32)
+    println (try do checked_sub_u64 0u64 1u64)
+    println (try do checked_sub_usz 0usz 1usz)
     println (try do checked_mul_i32 50_000 50_000)
     println (try do checked_mul_i32 -2_147_483_648 -1)
     println (try do checked_mul_i32 -12 3)
-    println <| overflowing_add_i32 40 2
-    println <| overflowing_add_i32 2_147_483_647 1
-    println <| overflowing_sub_i32 40 2
-    println <| overflowing_sub_i32 -2_147_483_648 1
-    println <| overflowing_mul_i32 -12 3
-    println <| overflowing_mul_i32 -2_147_483_648 -1
+    println (try do checked_mul_i8 12i8 10i8)
+    println (try do checked_mul_i8 64i8 2i8)
+    println (try do checked_mul_i16 200i16 100i16)
+    println (try do checked_mul_i16 256i16 256i16)
+    println (try do checked_mul_i64 3_000_000_000i64 3_000_000_000i64)
+    println (try do checked_mul_i64 4_000_000_000i64 4_000_000_000i64)
+    println (try do checked_mul_isz 3_000_000_000isz 3_000_000_000isz)
+    println (try do checked_mul_isz 4_000_000_000isz 4_000_000_000isz)
+    println (try do checked_mul_u8 15u8 17u8)
+    println (try do checked_mul_u8 16u8 16u8)
+    println (try do checked_mul_u16 255u16 257u16)
+    println (try do checked_mul_u16 256u16 256u16)
+    println (try do checked_mul_u32 65_535u32 65_537u32)
+    println (try do checked_mul_u32 65_536u32 65_536u32)
+    println (try do checked_mul_u64 4_000_000_000u64 4_000_000_000u64)
+    println (try do checked_mul_u64 5_000_000_000u64 5_000_000_000u64)
+    println (try do checked_mul_usz 4_000_000_000usz 4_000_000_000usz)
+    println (try do checked_mul_usz 5_000_000_000usz 5_000_000_000usz)
+    println (try do checked_add 40 2)
+    println (try do checked_sub 40 2)
+    println (try do checked_mul -12 3)
+    println (try do checked_add 120i8 7i8)
+    println (try do checked_add 250u8 5u8)
+    println (try do checked_mul 3_000_000_000i64 3_000_000_000i64)
+    println (try do checked_mul 4_000_000_000u64 4_000_000_000u64)
 
 // args: --delete-binary --no-color
 // expected stdout:
@@ -37,13 +81,50 @@ main () =
 // None
 // Some 42
 // None
+// None
+// None
+// None
+// None
+// None
+// None
+// None
+// None
+// None
 // Some 38
 // None
 // None
+// None
+// None
+// None
+// None
+// None
+// None
+// None
+// None
+// None
 // Some -36
-// 42, false
-// -2_147_483_648, true
-// 38, false
-// 2147483647, true
-// -36, false
-// -2_147_483_648, true
+// Some 120
+// None
+// Some 20000
+// None
+// Some 9000000000000000000
+// None
+// Some 9000000000000000000
+// None
+// Some 255
+// None
+// Some 65535
+// None
+// Some 4294967295
+// None
+// Some 16000000000000000000
+// None
+// Some 16000000000000000000
+// None
+// Some 42
+// Some 38
+// Some -36
+// Some 127
+// Some 255
+// Some 9000000000000000000
+// Some 16000000000000000000

--- a/examples/codegen/stdlib-tests/string.an
+++ b/examples/codegen/stdlib-tests/string.an
@@ -1,4 +1,8 @@
-import Std.String.bytes, chars, substr, string_of, join, split, reverse, parse_i32
+import Std.String.bytes, chars, substr, string_of, join, split, reverse
+import Std.String.parse_i8, parse_i16, parse_i32, parse_i64, parse_isz
+import Std.String.parse_u8, parse_u16, parse_u32, parse_u64, parse_usz
+import Std.String.try_cast_string_i8, try_cast_string_i16, try_cast_string_i32, try_cast_string_i64, try_cast_string_isz
+import Std.String.try_cast_string_u8, try_cast_string_u16, try_cast_string_u32, try_cast_string_u64, try_cast_string_usz
 import Std.Stream.iter, intersperse, stream_fn, Emit, emit
 import Std.String.starts_with, ends_with, contains, trim, trim_start, trim_end
 import Std.Fail.try
@@ -79,6 +83,75 @@ test_parse () =
     println (try do parse_i32 "-2147483648")
     println (try do parse_i32 "-2147483649")
     println (try do parse_i32 "-999999999999999999999999999")
+    parsed: Maybe I32 = try do try_cast "321"
+    println parsed
+    println (try do parse_i8 "127")
+    println (try do parse_i8 "128")
+    println (try do parse_i8 "-128")
+    println (try do parse_i8 "-129")
+    println (try do parse_i16 "32767")
+    println (try do parse_i16 "32768")
+    println (try do parse_i16 "-32768")
+    println (try do parse_i16 "-32769")
+    println (try do parse_i64 "123456789012345")
+    println (try do parse_i64 "-9223372036854775808")
+    println (try do parse_i64 "-9223372036854775809")
+    println (try do parse_i64 "9223372036854775808")
+    println (try do parse_isz "12345")
+    println (try do parse_isz "-12345")
+    println (try do parse_u8 "255")
+    println (try do parse_u8 "256")
+    println (try do parse_u8 "+255")
+    println (try do parse_u8 "-1")
+    println (try do parse_u16 "65535")
+    println (try do parse_u16 "65536")
+    println (try do parse_u16 "+65535")
+    println (try do parse_u32 "4294967295")
+    println (try do parse_u32 "4294967296")
+    println (try do parse_u32 "+4294967295")
+    println (try do parse_u64 "18446744073709551615")
+    println (try do parse_u64 "18446744073709551616")
+    println (try do parse_u64 "+18446744073709551615")
+    println (try do parse_usz "12345")
+    println (try do parse_usz "+12345")
+    from_i8: Maybe I8 = try do try_cast "-5"
+    println from_i8
+    from_i8_overflow: Maybe I8 = try do try_cast "128"
+    println from_i8_overflow
+    from_i16: Maybe I16 = try do try_cast "-123"
+    println from_i16
+    from_i16_overflow: Maybe I16 = try do try_cast "32768"
+    println from_i16_overflow
+    from_i32: Maybe I32 = try do try_cast "-123456"
+    println from_i32
+    from_i32_overflow: Maybe I32 = try do try_cast "2147483648"
+    println from_i32_overflow
+    from_i64: Maybe I64 = try do try_cast "123456789"
+    println from_i64
+    from_i64_overflow: Maybe I64 = try do try_cast "9223372036854775808"
+    println from_i64_overflow
+    from_isz: Maybe Isz = try do try_cast "-12345"
+    println from_isz
+    from_u8: Maybe U8 = try do try_cast "42"
+    println from_u8
+    from_u8_negative: Maybe U8 = try do try_cast "-1"
+    println from_u8_negative
+    from_u8_overflow: Maybe U8 = try do try_cast "256"
+    println from_u8_overflow
+    from_u16: Maybe U16 = try do try_cast "65535"
+    println from_u16
+    from_u16_overflow: Maybe U16 = try do try_cast "65536"
+    println from_u16_overflow
+    from_u32: Maybe U32 = try do try_cast "4294967295"
+    println from_u32
+    from_u32_overflow: Maybe U32 = try do try_cast "4294967296"
+    println from_u32_overflow
+    from_u64: Maybe U64 = try do try_cast "42"
+    println from_u64
+    from_u64_overflow: Maybe U64 = try do try_cast "18446744073709551616"
+    println from_u64_overflow
+    from_usz: Maybe Usz = try do try_cast "12345"
+    println from_usz
 
 // args: --delete-binary --no-color
 // expected stdout:
@@ -139,3 +212,52 @@ test_parse () =
 // Some -2_147_483_648
 // None
 // None
+// Some 321
+// Some 127
+// None
+// Some -128
+// None
+// Some 32767
+// None
+// Some -32_768
+// None
+// Some 123456789012345
+// Some -9_223_372_036_854_775_808
+// None
+// None
+// Some 12345
+// Some -12345
+// Some 255
+// None
+// Some 255
+// None
+// Some 65535
+// None
+// Some 65535
+// Some 4294967295
+// None
+// Some 4294967295
+// Some 18446744073709551615
+// None
+// Some 18446744073709551615
+// Some 12345
+// Some 12345
+// Some -5
+// None
+// Some -123
+// None
+// Some -123456
+// None
+// Some 123456789
+// None
+// Some -12345
+// Some 42
+// None
+// None
+// Some 65535
+// None
+// Some 4294967295
+// None
+// Some 42
+// None
+// Some 12345

--- a/stdlib/src/Math.an
+++ b/stdlib/src/Math.an
@@ -4,8 +4,15 @@ export sqrt, sqrtf, cbrt, pow, powf, exp, log, log2, log10,
     sin, cos, tan, asin, acos, atan, atan2,
     floor, ceil, round, trunc, fmod, hypot,
     pi, tau, e, abs,
-    overflowing_add_i32, overflowing_sub_i32, overflowing_mul_i32,
-    checked_add_i32, checked_sub_i32, checked_mul_i32
+    CheckedNum, checked_add, checked_sub, checked_mul,
+    checked_num_i8, checked_num_i16, checked_num_i32, checked_num_i64, checked_num_isz,
+    checked_num_u8, checked_num_u16, checked_num_u32, checked_num_u64, checked_num_usz,
+    checked_add_i8, checked_add_i16, checked_add_i32, checked_add_i64, checked_add_isz,
+    checked_add_u8, checked_add_u16, checked_add_u32, checked_add_u64, checked_add_usz,
+    checked_sub_i8, checked_sub_i16, checked_sub_i32, checked_sub_i64, checked_sub_isz,
+    checked_sub_u8, checked_sub_u16, checked_sub_u32, checked_sub_u64, checked_sub_usz,
+    checked_mul_i8, checked_mul_i16, checked_mul_i32, checked_mul_i64, checked_mul_isz,
+    checked_mul_u8, checked_mul_u16, checked_mul_u32, checked_mul_u64, checked_mul_usz
 
 // Libm wrappers
 sqrt = extern "sqrt": fn F64 -> F64
@@ -46,9 +53,64 @@ abs (x: t) {n: Num t} {Copy t}: t =
     (-) = n.sub.(-)
     if x < n.zero then n.zero - x else x
 
+checked_add_i8 (x: I8) (y: I8) {Fail}: I8 =
+    result, overflowed = overflowing_add_i8 x y
+    fail_if overflowed
+    result
+
+checked_add_i16 (x: I16) (y: I16) {Fail}: I16 =
+    result, overflowed = overflowing_add_i16 x y
+    fail_if overflowed
+    result
+
 /// Add two I32 values, failing on overflow.
 checked_add_i32 (x: I32) (y: I32) {Fail}: I32 =
     result, overflowed = overflowing_add_i32 x y
+    fail_if overflowed
+    result
+
+checked_add_i64 (x: I64) (y: I64) {Fail}: I64 =
+    result, overflowed = overflowing_add_i64 x y
+    fail_if overflowed
+    result
+
+checked_add_isz (x: Isz) (y: Isz) {Fail}: Isz =
+    result, overflowed = overflowing_add_isz x y
+    fail_if overflowed
+    result
+
+checked_add_u8 (x: U8) (y: U8) {Fail}: U8 =
+    result, overflowed = overflowing_add_u8 x y
+    fail_if overflowed
+    result
+
+checked_add_u16 (x: U16) (y: U16) {Fail}: U16 =
+    result, overflowed = overflowing_add_u16 x y
+    fail_if overflowed
+    result
+
+checked_add_u32 (x: U32) (y: U32) {Fail}: U32 =
+    result, overflowed = overflowing_add_u32 x y
+    fail_if overflowed
+    result
+
+checked_add_u64 (x: U64) (y: U64) {Fail}: U64 =
+    result, overflowed = overflowing_add_u64 x y
+    fail_if overflowed
+    result
+
+checked_add_usz (x: Usz) (y: Usz) {Fail}: Usz =
+    result, overflowed = overflowing_add_usz x y
+    fail_if overflowed
+    result
+
+checked_sub_i8 (x: I8) (y: I8) {Fail}: I8 =
+    result, overflowed = overflowing_sub_i8 x y
+    fail_if overflowed
+    result
+
+checked_sub_i16 (x: I16) (y: I16) {Fail}: I16 =
+    result, overflowed = overflowing_sub_i16 x y
     fail_if overflowed
     result
 
@@ -58,23 +120,239 @@ checked_sub_i32 (x: I32) (y: I32) {Fail}: I32 =
     fail_if overflowed
     result
 
+checked_sub_i64 (x: I64) (y: I64) {Fail}: I64 =
+    result, overflowed = overflowing_sub_i64 x y
+    fail_if overflowed
+    result
+
+checked_sub_isz (x: Isz) (y: Isz) {Fail}: Isz =
+    result, overflowed = overflowing_sub_isz x y
+    fail_if overflowed
+    result
+
+checked_sub_u8 (x: U8) (y: U8) {Fail}: U8 =
+    result, overflowed = overflowing_sub_u8 x y
+    fail_if overflowed
+    result
+
+checked_sub_u16 (x: U16) (y: U16) {Fail}: U16 =
+    result, overflowed = overflowing_sub_u16 x y
+    fail_if overflowed
+    result
+
+checked_sub_u32 (x: U32) (y: U32) {Fail}: U32 =
+    result, overflowed = overflowing_sub_u32 x y
+    fail_if overflowed
+    result
+
+checked_sub_u64 (x: U64) (y: U64) {Fail}: U64 =
+    result, overflowed = overflowing_sub_u64 x y
+    fail_if overflowed
+    result
+
+checked_sub_usz (x: Usz) (y: Usz) {Fail}: Usz =
+    result, overflowed = overflowing_sub_usz x y
+    fail_if overflowed
+    result
+
+checked_mul_i8 (x: I8) (y: I8) {Fail}: I8 =
+    result, overflowed = overflowing_mul_i8 x y
+    fail_if overflowed
+    result
+
+checked_mul_i16 (x: I16) (y: I16) {Fail}: I16 =
+    result, overflowed = overflowing_mul_i16 x y
+    fail_if overflowed
+    result
+
 /// Multiply two I32 values, failing on overflow.
 checked_mul_i32 (x: I32) (y: I32) {Fail}: I32 =
     result, overflowed = overflowing_mul_i32 x y
     fail_if overflowed
     result
 
+checked_mul_i64 (x: I64) (y: I64) {Fail}: I64 =
+    result, overflowed = overflowing_mul_i64 x y
+    fail_if overflowed
+    result
+
+checked_mul_isz (x: Isz) (y: Isz) {Fail}: Isz =
+    result, overflowed = overflowing_mul_isz x y
+    fail_if overflowed
+    result
+
+checked_mul_u8 (x: U8) (y: U8) {Fail}: U8 =
+    result, overflowed = overflowing_mul_u8 x y
+    fail_if overflowed
+    result
+
+checked_mul_u16 (x: U16) (y: U16) {Fail}: U16 =
+    result, overflowed = overflowing_mul_u16 x y
+    fail_if overflowed
+    result
+
+checked_mul_u32 (x: U32) (y: U32) {Fail}: U32 =
+    result, overflowed = overflowing_mul_u32 x y
+    fail_if overflowed
+    result
+
+checked_mul_u64 (x: U64) (y: U64) {Fail}: U64 =
+    result, overflowed = overflowing_mul_u64 x y
+    fail_if overflowed
+    result
+
+checked_mul_usz (x: Usz) (y: Usz) {Fail}: Usz =
+    result, overflowed = overflowing_mul_usz x y
+    fail_if overflowed
+    result
+
+overflowing_add_i8 (x: I8) (y: I8): (I8, Bool) =
+    intrinsic "OverflowingAddInt" x y
+
+overflowing_add_i16 (x: I16) (y: I16): (I16, Bool) =
+    intrinsic "OverflowingAddInt" x y
+
 /// Add two I32 values, returning the wrapped result and whether overflow occurred.
 overflowing_add_i32 (x: I32) (y: I32): (I32, Bool) =
     intrinsic "OverflowingAddInt" x y
+
+overflowing_add_i64 (x: I64) (y: I64): (I64, Bool) =
+    intrinsic "OverflowingAddInt" x y
+
+overflowing_add_isz (x: Isz) (y: Isz): (Isz, Bool) =
+    intrinsic "OverflowingAddInt" x y
+
+overflowing_add_u8 (x: U8) (y: U8): (U8, Bool) =
+    intrinsic "OverflowingAddInt" x y
+
+overflowing_add_u16 (x: U16) (y: U16): (U16, Bool) =
+    intrinsic "OverflowingAddInt" x y
+
+overflowing_add_u32 (x: U32) (y: U32): (U32, Bool) =
+    intrinsic "OverflowingAddInt" x y
+
+overflowing_add_u64 (x: U64) (y: U64): (U64, Bool) =
+    intrinsic "OverflowingAddInt" x y
+
+overflowing_add_usz (x: Usz) (y: Usz): (Usz, Bool) =
+    intrinsic "OverflowingAddInt" x y
+
+overflowing_sub_i8 (x: I8) (y: I8): (I8, Bool) =
+    intrinsic "OverflowingSubInt" x y
+
+overflowing_sub_i16 (x: I16) (y: I16): (I16, Bool) =
+    intrinsic "OverflowingSubInt" x y
 
 /// Subtract two I32 values, returning the wrapped result and whether overflow occurred.
 overflowing_sub_i32 (x: I32) (y: I32): (I32, Bool) =
     intrinsic "OverflowingSubInt" x y
 
+overflowing_sub_i64 (x: I64) (y: I64): (I64, Bool) =
+    intrinsic "OverflowingSubInt" x y
+
+overflowing_sub_isz (x: Isz) (y: Isz): (Isz, Bool) =
+    intrinsic "OverflowingSubInt" x y
+
+overflowing_sub_u8 (x: U8) (y: U8): (U8, Bool) =
+    intrinsic "OverflowingSubInt" x y
+
+overflowing_sub_u16 (x: U16) (y: U16): (U16, Bool) =
+    intrinsic "OverflowingSubInt" x y
+
+overflowing_sub_u32 (x: U32) (y: U32): (U32, Bool) =
+    intrinsic "OverflowingSubInt" x y
+
+overflowing_sub_u64 (x: U64) (y: U64): (U64, Bool) =
+    intrinsic "OverflowingSubInt" x y
+
+overflowing_sub_usz (x: Usz) (y: Usz): (Usz, Bool) =
+    intrinsic "OverflowingSubInt" x y
+
+overflowing_mul_i8 (x: I8) (y: I8): (I8, Bool) =
+    intrinsic "OverflowingMulInt" x y
+
+overflowing_mul_i16 (x: I16) (y: I16): (I16, Bool) =
+    intrinsic "OverflowingMulInt" x y
+
 /// Multiply two I32 values, returning the wrapped result and whether overflow occurred.
 overflowing_mul_i32 (x: I32) (y: I32): (I32, Bool) =
     intrinsic "OverflowingMulInt" x y
+
+overflowing_mul_i64 (x: I64) (y: I64): (I64, Bool) =
+    intrinsic "OverflowingMulInt" x y
+
+overflowing_mul_isz (x: Isz) (y: Isz): (Isz, Bool) =
+    intrinsic "OverflowingMulInt" x y
+
+overflowing_mul_u8 (x: U8) (y: U8): (U8, Bool) =
+    intrinsic "OverflowingMulInt" x y
+
+overflowing_mul_u16 (x: U16) (y: U16): (U16, Bool) =
+    intrinsic "OverflowingMulInt" x y
+
+overflowing_mul_u32 (x: U32) (y: U32): (U32, Bool) =
+    intrinsic "OverflowingMulInt" x y
+
+overflowing_mul_u64 (x: U64) (y: U64): (U64, Bool) =
+    intrinsic "OverflowingMulInt" x y
+
+overflowing_mul_usz (x: Usz) (y: Usz): (Usz, Bool) =
+    intrinsic "OverflowingMulInt" x y
+
+ability CheckedNum t =
+    checked_add: fn t t {Fail} -> t
+    checked_sub: fn t t {Fail} -> t
+    checked_mul: fn t t {Fail} -> t
+
+impl checked_num_i8: CheckedNum I8 with
+    checked_add = checked_add_i8
+    checked_sub = checked_sub_i8
+    checked_mul = checked_mul_i8
+
+impl checked_num_i16: CheckedNum I16 with
+    checked_add = checked_add_i16
+    checked_sub = checked_sub_i16
+    checked_mul = checked_mul_i16
+
+impl checked_num_i32: CheckedNum I32 with
+    checked_add = checked_add_i32
+    checked_sub = checked_sub_i32
+    checked_mul = checked_mul_i32
+
+impl checked_num_i64: CheckedNum I64 with
+    checked_add = checked_add_i64
+    checked_sub = checked_sub_i64
+    checked_mul = checked_mul_i64
+
+impl checked_num_isz: CheckedNum Isz with
+    checked_add = checked_add_isz
+    checked_sub = checked_sub_isz
+    checked_mul = checked_mul_isz
+
+impl checked_num_u8: CheckedNum U8 with
+    checked_add = checked_add_u8
+    checked_sub = checked_sub_u8
+    checked_mul = checked_mul_u8
+
+impl checked_num_u16: CheckedNum U16 with
+    checked_add = checked_add_u16
+    checked_sub = checked_sub_u16
+    checked_mul = checked_mul_u16
+
+impl checked_num_u32: CheckedNum U32 with
+    checked_add = checked_add_u32
+    checked_sub = checked_sub_u32
+    checked_mul = checked_mul_u32
+
+impl checked_num_u64: CheckedNum U64 with
+    checked_add = checked_add_u64
+    checked_sub = checked_sub_u64
+    checked_mul = checked_mul_u64
+
+impl checked_num_usz: CheckedNum Usz with
+    checked_add = checked_add_usz
+    checked_sub = checked_sub_usz
+    checked_mul = checked_mul_usz
 
 ability Bounded t =
     min: t

--- a/stdlib/src/String.an
+++ b/stdlib/src/String.an
@@ -3,7 +3,9 @@ import Std.C.malloc, memcpy, memcmp
 import Std.Stream.Emit, emit, Stream, foldl, map, stream_fn
 import Std.Vec.Vec
 import Std.Char.is_whitespace, to_digit
-import Std.Math.checked_add_i32, checked_sub_i32, checked_mul_i32
+import Std.Math.CheckedNum, checked_add, checked_sub, checked_mul
+import Std.Math.checked_num_i8, checked_num_i16, checked_num_i32, checked_num_i64, checked_num_isz
+import Std.Math.checked_num_u8, checked_num_u16, checked_num_u32, checked_num_u64, checked_num_usz
 import Std.Fail.Fail, fail, fail_if
 
 // TODO: All functions in this file should be a method on String, but String isn't defined in this file
@@ -146,6 +148,36 @@ trim (s: String): String =
 ///
 /// Fails for empty strings, sign-only strings, non-digits, or overflow.
 parse_i32 (s: String) {Fail}: I32 =
+    parse_signed_int s
+
+parse_i8 (s: String) {Fail}: I8 =
+    parse_signed_int s
+
+parse_i16 (s: String) {Fail}: I16 =
+    parse_signed_int s
+
+parse_i64 (s: String) {Fail}: I64 =
+    parse_signed_int s
+
+parse_isz (s: String) {Fail}: Isz =
+    parse_signed_int s
+
+parse_u8 (s: String) {Fail}: U8 =
+    parse_unsigned_int s
+
+parse_u16 (s: String) {Fail}: U16 =
+    parse_unsigned_int s
+
+parse_u32 (s: String) {Fail}: U32 =
+    parse_unsigned_int s
+
+parse_u64 (s: String) {Fail}: U64 =
+    parse_unsigned_int s
+
+parse_usz (s: String) {Fail}: Usz =
+    parse_unsigned_int s
+
+parse_signed_int (s: String) {n: Num t} {CheckedNum t} {Cast I32 t} {Copy t} {Fail}: t =
     len = Usz s.length
     fail_if (len == 0)
 
@@ -161,20 +193,80 @@ parse_i32 (s: String) {Fail}: I32 =
 
     fail_if (i == len)
 
-    var result = 0i32
+    ten: t = cast 10
+    var result = n.zero
 
     while i < len do
-        digit = match to_digit s.data.[i]
-        | Some d -> I32 d
+        digit: t = match to_digit s.data.[i]
+        | Some d -> cast (I32 d)
         | None -> fail ()
 
-        result := checked_mul_i32 result 10
+        result := checked_mul result ten.*
 
         if negative then
-            result := checked_sub_i32 result digit
+            result := checked_sub result digit
         else
-            result := checked_add_i32 result digit
+            result := checked_add result digit
 
         i += 1
 
     result
+
+parse_unsigned_int (s: String) {n: Num t} {CheckedNum t} {Cast U8 t} {Copy t} {Fail}: t =
+    len = Usz s.length
+    fail_if (len == 0)
+
+    var i = 0usz
+
+    first: Char = s.data.[0]
+    fail_if (first == '-')
+    if first == '+' then
+        i += 1
+
+    fail_if (i == len)
+
+    ten: t = cast 10u8
+    var result = n.zero
+
+    while i < len do
+        digit: t = match to_digit s.data.[i]
+        | Some d -> cast d
+        | None -> fail ()
+
+        result := checked_mul result ten.*
+
+        result := checked_add result digit
+
+        i += 1
+
+    result
+
+impl try_cast_string_i8: TryCast String I8 with
+    try_cast s {Fail} = parse_i8 s
+
+impl try_cast_string_i16: TryCast String I16 with
+    try_cast s {Fail} = parse_i16 s
+
+impl try_cast_string_i32: TryCast String I32 with
+    try_cast s {Fail} = parse_i32 s
+
+impl try_cast_string_i64: TryCast String I64 with
+    try_cast s {Fail} = parse_i64 s
+
+impl try_cast_string_isz: TryCast String Isz with
+    try_cast s {Fail} = parse_isz s
+
+impl try_cast_string_u8: TryCast String U8 with
+    try_cast s {Fail} = parse_u8 s
+
+impl try_cast_string_u16: TryCast String U16 with
+    try_cast s {Fail} = parse_u16 s
+
+impl try_cast_string_u32: TryCast String U32 with
+    try_cast s {Fail} = parse_u32 s
+
+impl try_cast_string_u64: TryCast String U64 with
+    try_cast s {Fail} = parse_u64 s
+
+impl try_cast_string_usz: TryCast String Usz with
+    try_cast s {Fail} = parse_usz s


### PR DESCRIPTION
The big one! Most of this is trying to include relatively extensive testing (fuzz testing would be cool here!).

And then its lots of repetitions between the various integer types. Most functions being the exact same other than signature - it would be a nice place for macro/comptime to help (rust does it with a macro https://doc.rust-lang.org/src/core/num/mod.rs.html#1849).

One thing to note - I've chosen *not* to export the `overflowing_*` functions - these are the ones that look like the below and 
```
overflowing_sub_usz (x: Usz) (y: Usz): (Usz, Bool) =
    intrinsic "OverflowingSubInt" x y
```
And only export the `checked_*` functions with use `{Fail}`. I think this is the better API so we shouldnt expose those internal versions - but I think worth keeping as it prevents dotting `Intrinsic` around the place if they're used elsewhere. (this also means removing `overflowing_*_i32` functions from the last MR.

For other things to note I've added a `CheckedNum` ability
```
ability CheckedNum t =
    checked_add: fn t t {Fail} -> t
    checked_sub: fn t t {Fail} -> t
    checked_mul: fn t t {Fail} -> t
```
You'll see this makes the implementation neater by allowing us to use a generic `parse_signed_int` and `parse_unsigned_int` functions rather than having to have specifics for both. `CheckedNum` could go in Prelude.an, lmk what you think!