### PR TITLE
Fix stack-buffer over-read in C backend's transmute codegen

### DIFF
--- a/src/codegen/c/cfile.rs
+++ b/src/codegen/c/cfile.rs
@@ -150,6 +150,7 @@ typedef double ante_f64;
         self.type_declarations += "typedef struct { char _unused; } Unit;\n";
         self.function_declarations += "void* malloc(size_t);\n";
         self.function_declarations += "void* memcpy(void*, void*, size_t);\n";
+        self.function_declarations += "void* memset(void*, int, size_t);\n";
         self.function_declarations += "double fmod(double, double);\n";
         self
     }

--- a/src/codegen/c/mod.rs
+++ b/src/codegen/c/mod.rs
@@ -931,6 +931,9 @@ impl Builder {
             },
             mir::Instruction::Transmute(value) => {
                 // C can't reinterpret an rvalue's bits directly, so round-trip through memcpy.
+                // Copy only min(sizeof(src), sizeof(dst)) bytes: a widening transmute (e.g. a
+                // small union variant into the max-size union type) would otherwise read past
+                // the source. The destination is zero-initialized so the widened tail is defined.
                 let source = mir.type_of_value(value, definition);
                 self.write_declarator(&source, &|this| {
                     let _ = write!(this.current_item, "{id}_src");
@@ -942,9 +945,10 @@ impl Builder {
                 self.write_declarator(result, &|this| {
                     let _ = write!(this.current_item, "{id}");
                 });
-                let _ = write!(self.current_item, "; memcpy(&{id}, &{id}_src, sizeof(");
-                self.write_type(result, "");
-                self.write("));");
+                let _ = write!(
+                    self.current_item,
+                    "; memset(&{id}, 0, sizeof({id})); memcpy(&{id}, &{id}_src, sizeof({id}) < sizeof({id}_src) ? sizeof({id}) : sizeof({id}_src));"
+                );
             },
             mir::Instruction::Id(value) => {
                 self.write_result_binding(id, definition);


### PR DESCRIPTION
Fix stack-buffer over-read in C backend's transmute codegen

Unlike the LLVM bitcast, the C backend transmutes using memcpy. If destination > source, the source would be over-read.  Clamp it.

This upstreams commit af40ebcee1776b5d8dc81f0574d7ff31783599c9 from the "drop" feature branch.