### PR TITLE
Enable -fno-strict-aliasing for the C backend

### DIFF
--- a/examples/codegen/strict_aliasing.an
+++ b/examples/codegen/strict_aliasing.an
@@ -1,0 +1,16 @@
+// Caveat: This would cease to be a good test if the compiler were to inline the helper function
+// and constant-fold it.  4602678819172646912 = 0x3FE0000000000000
+
+bits_roundtrip (i: mut I64) (f: mut F64): I64 =
+    i.* := 11
+    f.* := 0.5
+    i.*
+
+main () =
+    var x = 0 : I64
+    f = transmute (mut x) : mut F64
+    println (bits_roundtrip (mut x) f)
+
+// args: --delete-binary --no-color -O 3
+// expected stdout:
+// 4602678819172646912

--- a/src/codegen/c/mod.rs
+++ b/src/codegen/c/mod.rs
@@ -58,6 +58,7 @@ pub fn codegen_c_for_mir(
         .arg(&c_file_name)
         .arg(format!("-o{o_file_name}"))
         .arg(opt_level.as_cc_opt_string())
+        .arg("-fno-strict-aliasing")
         .arg("-c")
         .arg("-w")
         .spawn()


### PR DESCRIPTION
Enable -fno-strict-aliasing for the C backend
