### PR TITLE
cleanup error handling and add an `init` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,7 @@ dependencies = [
  "rmp-serde",
  "rustc-hash",
  "serde",
+ "tempfile",
  "toml",
 ]
 
@@ -98,9 +99,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "async-trait"
@@ -110,7 +111,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -121,7 +122,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -220,7 +221,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -310,7 +311,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -347,6 +348,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
@@ -431,7 +438,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -461,6 +468,18 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
 ]
 
 [[package]]
@@ -650,7 +669,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -696,7 +715,7 @@ checksum = "661e6798d974cb8c7e5bcad7d0a1eba45b044b0d29a8347894e66f5c4a013b9d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -730,7 +749,7 @@ checksum = "6cfe97ee860815a90ed17e09639513269e39420a7440f3f4c996f238c514cf8d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -776,6 +795,12 @@ checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -936,7 +961,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -962,6 +987,12 @@ checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rangemap"
@@ -1072,6 +1103,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.13.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "scc"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1126,7 +1170,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1150,7 +1194,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1242,6 +1286,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1249,7 +1304,20 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1263,22 +1331,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1316,7 +1384,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1422,7 +1490,7 @@ checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1450,7 +1518,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1506,6 +1574,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1542,6 +1619,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "write16"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1573,7 +1656,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -1594,7 +1677,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -1617,7 +1700,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ mimalloc = { version = "0.1", default-features = false }
 [dev-dependencies]
 # Enabling 'parallel' makes `cargo t` nondeterministic
 goldentests = { version = "1.4.2", default-features = false }
+tempfile = "3"
 
 [profile.release]
 debug = true

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,6 +3,8 @@ use std::{ffi::OsString, path::PathBuf};
 use clap::{Args, CommandFactory, Parser, ValueEnum, ValueHint, error::ErrorKind};
 use clap_complete::Shell;
 
+use crate::{dependencies, project};
+
 #[derive(Parser, Debug)]
 pub struct Completions {
     #[arg(long)]
@@ -14,6 +16,8 @@ pub enum Commands {
     Run(RunArgs),
     /// Clone a git dependency into this project's dependency directory
     Add(AddArgs),
+    /// Inits an ante project
+    Init(InitArgs),
 }
 
 #[derive(Parser, Debug)]
@@ -149,6 +153,50 @@ pub struct CompileArgs {
     /// Add a directory to the native library search path when linking. May be repeated.
     #[arg(long = "link-search", short = 'L', value_name = "PATH", value_hint = ValueHint::DirPath)]
     pub link_search: Vec<PathBuf>,
+}
+
+#[derive(Args, Debug)]
+pub struct InitArgs {
+    #[arg(default_value = ".", value_hint = ValueHint::DirPath)]
+    pub path: PathBuf,
+}
+
+/// CommandError represents an error propagated up by any commands.
+/// This should be extensive and is useful for pretty printing
+#[derive(Debug)]
+pub enum CommandError {
+    Dependency(dependencies::DependencyError),
+    InitProject(project::InitProjectError),
+}
+
+impl std::fmt::Display for CommandError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Dependency(error) => write!(formatter, "Failed to add Dependency: {error}"),
+            Self::InitProject(error) => write!(formatter, "Failed to init project: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for CommandError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Dependency(error) => Some(error),
+            Self::InitProject(error) => Some(error),
+        }
+    }
+}
+
+impl From<dependencies::DependencyError> for CommandError {
+    fn from(error: dependencies::DependencyError) -> Self {
+        Self::Dependency(error)
+    }
+}
+
+impl From<project::InitProjectError> for CommandError {
+    fn from(error: project::InitProjectError) -> Self {
+        Self::InitProject(error)
+    }
 }
 
 impl CompileArgs {

--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -14,7 +14,7 @@ pub enum DependencyError {
 impl fmt::Display for DependencyError {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::MissingProjectRoot => write!(formatter, "Missing project root; please create one with `ante init`"),
+            Self::MissingProjectRoot => write!(formatter, "Missing project root, please create one with `ante init`"),
             Self::Io(error) => error.fmt(formatter),
             Self::GitClone(error) => write!(formatter, "Git clone failed: {error}"),
         }

--- a/src/dependencies.rs
+++ b/src/dependencies.rs
@@ -1,38 +1,60 @@
-use std::process::Command;
+use std::{error::Error, fmt, io::Error as IoError, path::PathBuf, process::Command};
 
-use colored::Colorize;
-
-use crate::{find_files::find_nearest_project_root, manifest::MANIFEST_FILE_NAME};
+use crate::find_files::find_nearest_project_root;
 
 pub const DEPENDENCIES_DIR_NAME: &str = "deps";
 
-/// Add a git dependency to the current Ante project by cloning it into the dependencies directory.
-pub fn add_git_dependency(dep_url: &str) {
-    let Some(project_root) = find_nearest_project_root() else {
-        eprintln!(
-            "{}: could not find {MANIFEST_FILE_NAME} in the current directory or any parent directory",
-            "error".red(),
-        );
-        std::process::exit(1);
-    };
+#[derive(Debug)]
+pub enum DependencyError {
+    MissingProjectRoot,
+    Io(IoError),
+    GitClone(String),
+}
 
-    let deps_dir = project_root.join(DEPENDENCIES_DIR_NAME);
-    if let Err(error) = std::fs::create_dir_all(&deps_dir) {
-        eprintln!("{}: failed to create `{}`:\n{error}", "error".red(), deps_dir.display());
-        std::process::exit(1);
+impl fmt::Display for DependencyError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingProjectRoot => write!(formatter, "Missing project root; please create one with `ante init`"),
+            Self::Io(error) => error.fmt(formatter),
+            Self::GitClone(error) => write!(formatter, "Git clone failed: {error}"),
+        }
     }
+}
 
-    let status = Command::new("git").arg("clone").arg(dep_url).current_dir(&deps_dir).status();
+impl Error for DependencyError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Io(error) => Some(error),
+            Self::MissingProjectRoot | Self::GitClone(_) => None,
+        }
+    }
+}
+
+impl From<IoError> for DependencyError {
+    fn from(error: IoError) -> Self {
+        Self::Io(error)
+    }
+}
+
+/// Add a git dependency to the current Ante project by cloning it into the dependencies directory.
+pub fn add_dependency(dep_url: &str) -> Result<(), DependencyError> {
+    let project_root = find_nearest_project_root().ok_or(DependencyError::MissingProjectRoot)?;
+    add_git_dependency(&project_root, dep_url)
+}
+
+/// Add a git dependency to the current Ante project by cloning it into the dependencies directory.
+fn add_git_dependency(project_root: &PathBuf, dep_url: &str) -> Result<(), DependencyError> {
+    let deps_dir = project_root.join(DEPENDENCIES_DIR_NAME);
+
+    std::fs::create_dir_all(&deps_dir)?;
+
+    let status = Command::new("git").arg("clone").arg(dep_url).current_dir(&deps_dir).status()?;
+
     match status {
-        Ok(status) if status.success() => (),
-        Ok(status) => {
+        status if status.success() => Ok(()),
+        status => {
             let code = status.code().map_or_else(|| "terminated by signal".to_string(), |code| code.to_string());
-            eprintln!("{}: git clone failed with exit status {code}", "error".red());
-            std::process::exit(1);
-        },
-        Err(error) => {
-            eprintln!("{}: failed to run git clone:\n{error}", "error".red());
-            std::process::exit(1);
+            Err(DependencyError::GitClone(code))
         },
     }
 }

--- a/src/find_files.rs
+++ b/src/find_files.rs
@@ -14,16 +14,13 @@ use crate::{
     manifest::{MANIFEST_FILE_NAME, Manifest},
     name_resolution::namespace::{CrateId, SourceFileId},
     paths::stdlib_path,
+    project::{MAIN_FILE, SRC_FOLDER},
 };
 
 pub type CrateGraph = BTreeMap<CrateId, Crate>;
 
 /// Default name of the local crate when its `ante.toml` has no `name` field.
 pub const DEFAULT_LOCAL_CRATE_NAME: &str = "Local";
-
-/// Default name of the src folder.
-pub(crate) const SRC_FOLDER: &str = "src";
-pub(crate) const MAIN_FILE: &str = "main.an";
 
 /// Search the current directory and its ancestors for an Ante manifest.
 pub fn find_nearest_project_root() -> Option<PathBuf> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,12 +9,14 @@ pub mod parser;
 pub mod type_inference;
 
 // Util modules:
+pub mod cli;
 pub mod diagnostics;
 pub mod files;
 pub mod incremental;
 mod iterator_extensions;
 pub mod manifest;
 pub mod paths;
+pub mod project;
 pub mod seq;
 pub mod timings;
 pub mod vecmap;

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,7 @@ use std::{
 #[cfg(feature = "llvm")]
 use crate::codegen::llvm::codegen_llvm;
 use crate::{
-    cli::{EmitTarget, OptLevel},
+    cli::{CommandError, EmitTarget, OptLevel},
     diagnostics::{DiagnosticKind, collect_all_diagnostics},
     files::{make_compiler, write_metadata},
     incremental::{TargetPointerSize, TypeCheck, ValidateExports},
@@ -69,6 +69,7 @@ mod lexer;
 mod mir;
 mod name_resolution;
 mod parser;
+mod project;
 mod type_inference;
 
 mod cli;
@@ -129,6 +130,13 @@ impl CompileRequest {
 }
 
 fn main() {
+    if let Err(error) = run() {
+        eprintln!("{}: {error}", "error".red());
+        std::process::exit(1)
+    }
+}
+
+fn run() -> Result<(), CommandError> {
     if let Ok(Completions { shell_completion }) = Completions::try_parse() {
         let mut cmd = Cli::command();
         let name = cmd.get_name().to_string();
@@ -140,10 +148,13 @@ fn main() {
             Some(Commands::Run(args)) => {
                 compile(CompileRequest::project(args.compile, true, args.delete_binary, args.program_args))
             },
-            Some(Commands::Add(args)) => dependencies::add_git_dependency(&args.dep_url),
+            Some(Commands::Add(args)) => dependencies::add_dependency(&args.dep_url)?,
+            Some(Commands::Init(args)) => project::init_project(&args.path)?,
             None => compile(CompileRequest::files(file)),
         }
     }
+
+    Ok(())
 }
 
 fn compile(request: CompileRequest) {

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,10 +1,10 @@
-use std::path::Path;
+use std::{error::Error, fmt, io::Error as IoError, path::Path};
 
 use crate::incremental::Crate;
 
 pub const MANIFEST_FILE_NAME: &str = "ante.toml";
 
-#[derive(serde::Deserialize, Default)]
+#[derive(serde::Deserialize, serde::Serialize, Default)]
 pub struct Manifest {
     pub name: Option<String>,
 
@@ -17,9 +17,57 @@ pub struct Manifest {
     pub link_search: Option<Vec<String>>,
 }
 
+#[derive(Debug)]
+pub enum CreateManifestError {
+    Io(IoError),
+    AlreadyExists,
+}
+
+impl fmt::Display for CreateManifestError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(error) => error.fmt(formatter),
+            Self::AlreadyExists => write!(formatter, "Manifest File Already Exists At This Location"),
+        }
+    }
+}
+
+impl Error for CreateManifestError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Io(error) => Some(error),
+            Self::AlreadyExists => None,
+        }
+    }
+}
+
+impl From<IoError> for CreateManifestError {
+    fn from(error: IoError) -> Self {
+        Self::Io(error)
+    }
+}
+
 impl Manifest {
+    /// Creates a manifest if it does not exist at the given path.
+    ///
+    /// Errors on IO problems or if the manifest already exists.
+    pub fn init(root: &Path) -> Result<(), CreateManifestError> {
+        let manifest_path = root.join(MANIFEST_FILE_NAME);
+
+        if std::fs::exists(&manifest_path)? {
+            return Err(CreateManifestError::AlreadyExists);
+        }
+
+        let name = root.canonicalize()?.file_name().map(|name| name.to_string_lossy().into_owned());
+        let default_manifest = Manifest { name, ..Manifest::default() };
+        let default_manifest_string =
+            toml::to_string_pretty(&default_manifest).expect("Failed to serialise default manifest");
+
+        Ok(std::fs::write(manifest_path, default_manifest_string)?)
+    }
+
     /// Read and parse the `ante.toml` manifest in the given crate root directory, if present.
-    pub fn read(root: &Path) -> Option<Manifest> {
+    pub fn read(root: &Path) -> Option<Self> {
         let contents = std::fs::read_to_string(root.join(MANIFEST_FILE_NAME)).ok()?;
         toml::from_str(&contents).ok()
     }

--- a/src/mir/builder/mod.rs
+++ b/src/mir/builder/mod.rs
@@ -575,7 +575,7 @@ where
             self.push_instruction(Instruction::GetFieldPtr { struct_ptr, struct_type, index }, Type::POINTER)
         } else {
             let value = self.expression(object_expr);
-            let tuple = self.deref_if_shared(value, &object_type);
+            let tuple = self.deref_if_shared(value, object_type);
             let element_type = match self.type_of_value(&tuple) {
                 Type::Tuple(elements) => elements.get(index as usize).cloned().unwrap_or(Type::ERROR),
                 _ => Type::ERROR,
@@ -2282,7 +2282,7 @@ where
             },
             cst::Pattern::Alias(name, inner) => {
                 if let Some(origin) = self.context().name_origin(*name) {
-                    self.define_variable(origin, value.clone());
+                    self.define_variable(origin, value);
                 }
                 self.bind_pattern(*inner, value);
             },

--- a/src/name_resolution/mod.rs
+++ b/src/name_resolution/mod.rs
@@ -12,7 +12,6 @@ pub mod namespace;
 
 use crate::{
     diagnostics::{Diagnostic, Location},
-    find_files::SRC_FOLDER,
     incremental::{
         self, DbHandle, ExportedTypes, GetCrateGraph, GetItem, Resolve, VisibleDefinitions, VisibleDefinitionsResult,
     },
@@ -26,6 +25,7 @@ use crate::{
         desugar_context::DesugarContext,
         ids::{ExprId, NameId, PathId, PatternId, TopLevelId, TopLevelName},
     },
+    project::SRC_FOLDER,
 };
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]

--- a/src/name_resolution/namespace.rs
+++ b/src/name_resolution/namespace.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{find_files::SRC_FOLDER, parser::ids::TopLevelId, paths::prelude_path_relative_to_stdlib_source_folder};
+use crate::{parser::ids::TopLevelId, paths::prelude_path_relative_to_stdlib_source_folder, project::SRC_FOLDER};
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub(super) enum Namespace {

--- a/src/project.rs
+++ b/src/project.rs
@@ -1,0 +1,164 @@
+use crate::manifest::{CreateManifestError, MANIFEST_FILE_NAME, Manifest};
+use std::{
+    error::Error,
+    fmt,
+    io::Error as IoError,
+    path::{Path, PathBuf},
+};
+
+/// Default name of the src folder.
+pub(crate) const SRC_FOLDER: &str = "src";
+pub(crate) const MAIN_FILE: &str = "main.an";
+const DEFAULT_MAIN_SOURCE: &str = r#"main () =
+    println "Hello, World!"
+"#;
+
+#[derive(Debug)]
+pub enum InitProjectError {
+    Manifest(CreateManifestError),
+    Io(IoError),
+    InvalidMainFile(PathBuf),
+}
+
+impl fmt::Display for InitProjectError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Manifest(error) => error.fmt(formatter),
+            Self::Io(error) => error.fmt(formatter),
+            Self::InvalidMainFile(path) => {
+                write!(
+                    formatter,
+                    "Cannot create main source file because `{}` exists and is not a file",
+                    path.display()
+                )
+            },
+        }
+    }
+}
+
+impl Error for InitProjectError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Manifest(error) => Some(error),
+            Self::Io(error) => Some(error),
+            Self::InvalidMainFile(_) => None,
+        }
+    }
+}
+
+impl From<CreateManifestError> for InitProjectError {
+    fn from(error: CreateManifestError) -> Self {
+        Self::Manifest(error)
+    }
+}
+
+impl From<IoError> for InitProjectError {
+    fn from(error: IoError) -> Self {
+        Self::Io(error)
+    }
+}
+
+pub fn init_project(path: &Path) -> Result<(), InitProjectError> {
+    std::fs::create_dir_all(path)?;
+
+    if std::fs::exists(path.join(MANIFEST_FILE_NAME))? {
+        return Err(CreateManifestError::AlreadyExists.into());
+    }
+
+    let source_dir = path.join(SRC_FOLDER);
+    std::fs::create_dir_all(&source_dir)?;
+
+    let main_file = source_dir.join(MAIN_FILE);
+    if main_file.exists() && !main_file.is_file() {
+        return Err(InitProjectError::InvalidMainFile(main_file));
+    } else if !main_file.exists() {
+        std::fs::write(main_file, DEFAULT_MAIN_SOURCE)?
+    }
+
+    Manifest::init(path)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn initializes_project() {
+        let directory = tempdir().unwrap();
+
+        init_project(directory.path()).unwrap();
+
+        assert!(directory.path().join("ante.toml").is_file());
+
+        let main_file = directory.path().join(SRC_FOLDER).join(MAIN_FILE);
+        assert!(main_file.is_file());
+        assert_eq!(fs::read_to_string(main_file).unwrap(), DEFAULT_MAIN_SOURCE);
+    }
+
+    #[test]
+    fn initializes_project_in_missing_directory() {
+        let directory = tempdir().unwrap();
+        let project_directory = directory.path().join("hello-world");
+
+        init_project(&project_directory).unwrap();
+
+        assert!(project_directory.join("ante.toml").is_file());
+        assert!(project_directory.join(SRC_FOLDER).join(MAIN_FILE).is_file());
+        assert_eq!(Manifest::read(&project_directory).unwrap().name.as_deref(), Some("hello-world"));
+    }
+
+    #[test]
+    fn rejects_existing_project() {
+        let directory = tempdir().unwrap();
+
+        init_project(directory.path()).unwrap();
+        let error = init_project(directory.path()).unwrap_err();
+
+        assert!(matches!(error, InitProjectError::Manifest(CreateManifestError::AlreadyExists)));
+    }
+
+    #[test]
+    fn preserves_existing_main_file() {
+        let directory = tempdir().unwrap();
+        let source_directory = directory.path().join(SRC_FOLDER);
+        fs::create_dir(&source_directory).unwrap();
+
+        let main_file = source_directory.join(MAIN_FILE);
+        let existing_source = "main () = print \"Existing\"\n";
+        fs::write(&main_file, existing_source).unwrap();
+
+        init_project(directory.path()).unwrap();
+
+        assert_eq!(fs::read_to_string(main_file).unwrap(), existing_source);
+    }
+
+    #[test]
+    fn leaves_no_manifest_when_source_directory_creation_fails() {
+        let directory = tempdir().unwrap();
+        let source_directory = directory.path().join(SRC_FOLDER);
+        fs::write(&source_directory, "not a directory").unwrap();
+
+        init_project(directory.path()).unwrap_err();
+
+        assert!(!directory.path().join(MANIFEST_FILE_NAME).exists());
+
+        fs::remove_file(source_directory).unwrap();
+        init_project(directory.path()).unwrap();
+        assert!(directory.path().join(MANIFEST_FILE_NAME).is_file());
+    }
+
+    #[test]
+    fn rejects_main_path_that_is_not_a_file() {
+        let directory = tempdir().unwrap();
+        let main_file = directory.path().join(SRC_FOLDER).join(MAIN_FILE);
+        fs::create_dir_all(&main_file).unwrap();
+
+        let error = init_project(directory.path()).unwrap_err();
+
+        assert!(matches!(error, InitProjectError::InvalidMainFile(path) if path == main_file));
+        assert!(!directory.path().join(MANIFEST_FILE_NAME).exists());
+    }
+}

--- a/src/type_inference/patterns.rs
+++ b/src/type_inference/patterns.rs
@@ -614,7 +614,7 @@ impl<'tc, 'local, 'db> MatchCompiler<'tc, 'local, 'db> {
                     let idx = constructor.variant_index();
                     let mut cols = row.columns;
 
-                    for (var, pat) in cases[idx].1.iter().zip(args.into_iter()) {
+                    for (var, pat) in cases[idx].1.iter().zip(args) {
                         cols.push(Column::new(*var, pat));
                     }
 

--- a/src/type_inference/types.rs
+++ b/src/type_inference/types.rs
@@ -908,7 +908,7 @@ impl Type {
     /// Walk every subterm of this type, although does not recur into [Type::Forall].
     fn for_each_subterm(&self, bindings: &TypeBindings, f: &mut impl FnMut(&Type, &TypeBindings)) {
         let typ = self.follow(bindings);
-        f(&typ, bindings);
+        f(typ, bindings);
         match typ {
             Type::Primitive(_) | Type::UserDefined(_) | Type::Variable(_) | Type::Generic(_) | Type::U32(_) => (),
             Type::Function(function) => {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,27 @@
+use std::process::{Command, Output};
+
+use tempfile::tempdir;
+
+fn assert_success(output: &Output) {
+    assert!(
+        output.status.success(),
+        "command failed with status {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
+#[test]
+fn init_creates_a_runnable_program() {
+    let directory = tempdir().unwrap();
+    let project = directory.path().join("hello-world");
+    let ante = env!("CARGO_BIN_EXE_ante");
+
+    let init = Command::new(ante).arg("init").arg(&project).output().unwrap();
+    assert_success(&init);
+
+    let run = Command::new(ante).args(["run", "--backend", "c"]).current_dir(&project).output().unwrap();
+    assert_success(&run);
+    assert_eq!(String::from_utf8_lossy(&run.stdout), "Hello, World!\n");
+}


### PR DESCRIPTION
Cleans up error handling to surface all errors to the runtime. We use system exit (1) so we can get a pretty message, we introduce thiserror so we can pass errors up the chain rather than scattering system exits everywhere.

Introduces a basic init command which inits a project at the given path (defaults to `.`). This creates an `ante.toml` and `src/main.an` with a hello world example. It tries to error out early where applicable. Example

```
~/Documents/personal/ante on  master ✗ ⌚ 15:21:49
$ ./target/debug/ante init ../hello-world

~/Documents/personal/ante on  master ✗ ⌚ 15:22:05
$ cat ../hello-world/ante.toml
name = "hello-world"

~/Documents/personal/ante on  master ✗ ⌚ 15:22:19
$ cat ../hello-world/src/main.an
main () = println "Hello, World!"

~/Documents/personal/ante on  master ✗ ⌚ 15:22:39
$ cd ../hello-world

~/Documents/personal/hello-world ⌚ 15:23:06
$ ../ante/target/debug/ante run
Hello, World!

~/Documents/personal/hello-world ⌚ 15:23:19
$ cd ../ante

~/Documents/personal/ante on  master ✗ ⌚ 15:23:23
$ ./target/debug/ante init ../hello-world
error: Failed to init project: Manifest File Already Exists

~/Documents/personal/ante on  master ✗ ⌚ 15:23:29
$
```

Also ran `cargo clippy --fix`

Let me know what you think of the use of `thiserror` and the current setup for init - a lot of this stuff is preference (e.g. over anyhow) so v happy if you have a preferred way of doing things