### PR TITLE
fix: hashmap bug across collisions and tombstones

### DIFF
--- a/examples/codegen/stdlib-tests/map.an
+++ b/examples/codegen/stdlib-tests/map.an
@@ -100,7 +100,7 @@ test_collision_management () =
     println (m.get first ~> try)
     println (m.get second ~> panic_on_fail)
     println (m.insert second 3)
-    println (m.get (ref second) ~> panic_on_fail)
+    println (m.get second ~> panic_on_fail)
     println (m.len ())
 
 

--- a/examples/codegen/stdlib-tests/map.an
+++ b/examples/codegen/stdlib-tests/map.an
@@ -97,8 +97,8 @@ test_collision_management () =
     // testing tombstone case
     m.remove (ref first)
     println (m.len ())
-    println (m.get (ref first) ~> try)
-    println (m.get (ref second) ~> panic_on_fail)
+    println (m.get first ~> try)
+    println (m.get second ~> panic_on_fail)
     println (m.insert second 3)
     println (m.get (ref second) ~> panic_on_fail)
     println (m.len ())

--- a/examples/codegen/stdlib-tests/map.an
+++ b/examples/codegen/stdlib-tests/map.an
@@ -91,8 +91,8 @@ test_collision_management () =
     // these have the same hash so should be put in the same index
     println (m.len ())
 
-    println (m.get (ref first) ~> panic_on_fail)
-    println (m.get (ref second) ~> panic_on_fail)
+    println (m.get first ~> panic_on_fail)
+    println (m.get second ~> panic_on_fail)
 
     // testing tombstone case
     m.remove (ref first)

--- a/examples/codegen/stdlib-tests/map.an
+++ b/examples/codegen/stdlib-tests/map.an
@@ -2,7 +2,7 @@ import Std.HashMap.HashMap, empty, of, clear, insert, print_hashmap, remove, get
     get_entry, stream_map
 import Std.Stream.iter, iota, map, stream_fn, stream_array
 import Std.Hash.Hash, hash_u8
-import Std.Fail.try
+import Std.Fail.try, panic_on_fail
 
 main () =
     var map = empty ()
@@ -32,6 +32,7 @@ main () =
     test_iter_and_clear ()
     test_get_or_insert_contains_and_merge ()
     test_insert_duplicate ()
+    test_collision_management ()
 
 test_iter_and_clear () =
     // stream_map impl: build a single-entry map (otherwise ordering isn't deterministic)
@@ -69,6 +70,40 @@ test_insert_duplicate () =
     println (m.insert 2 20)
     println (m.len ())
 
+
+type MyType = 
+    inner: Usz
+
+impl copy_mytype: Copy MyType with
+      (.*) = deref
+
+impl hash_mytype: Hash MyType with
+    hash _ = 1
+
+impl equal_mytype: Eq MyType with
+    (==) x y = x.inner == y.inner
+
+test_collision_management () =
+    first = MyType 1
+    second = MyType 2
+        
+    var m = HashMap.of [(first, 1), (second, 2)]
+    // these have the same hash so should be put in the same index
+    println (m.len ())
+
+    println (m.get (ref first) ~> panic_on_fail)
+    println (m.get (ref second) ~> panic_on_fail)
+
+    // testing tombstone case
+    m.remove (ref first)
+    println (m.len ())
+    println (m.get (ref first) ~> try)
+    println (m.get (ref second) ~> panic_on_fail)
+    println (m.insert second 3)
+    println (m.get (ref second) ~> panic_on_fail)
+    println (m.len ())
+
+
 // args: --delete-binary --no-color
 // expected stdout:
 // [1 -> 3, 2 -> 6, 3 -> 9, 4 -> 12, 6 -> 18, 7 -> 21]
@@ -89,4 +124,12 @@ test_insert_duplicate () =
 // Some 10
 // None
 // 2
-
+// 2
+// 1
+// 2
+// 1
+// None
+// 2
+// Some 2
+// 3
+// 1

--- a/stdlib/src/HashMap.an
+++ b/stdlib/src/HashMap.an
@@ -105,8 +105,7 @@ HashMap.insert (map: mut HashMap k v) (key: k) (value: v) {Hash k} {Eq k}: Maybe
         if not iter_until map key value 0 h then
             match first_tombstone
             | Some index ->
-                entry = ptr_to_mut (offset map.entries index)
-                entry := Entry (deref key) (deref value) true false
+                array_insert map.entries index (Entry (deref key) (deref value) true false)
             | None ->
                 panic "Failed to insert entry into map"
 

--- a/stdlib/src/HashMap.an
+++ b/stdlib/src/HashMap.an
@@ -135,7 +135,7 @@ HashMap.get_entry_mut (map: mut HashMap k v) (key: ref k) {Hash k} {eq: Eq k}: M
             entry_ptr = offset map.entries start
             entry = deref_ptr entry_ptr
             if entry.occupied then
-                if ref entry.key == key then
+                if entry.key == key then
                     Found entry_ptr
                 else
                     iter_until (start + 1) end

--- a/stdlib/src/HashMap.an
+++ b/stdlib/src/HashMap.an
@@ -93,9 +93,7 @@ HashMap.insert (map: mut HashMap k v) (key: k) (value: v) {Hash k} {Eq k}: Maybe
 
                 iter_until map key value (start + 1) end
             else
-                insertion_index = match first_tombstone
-                    | Some index -> index
-                    | None -> start
+                insertion_index = first_tombstone.unwrap_or_else do start
 
                 insertion_entry = ptr_to_mut (offset map.entries insertion_index)
                 insertion_entry := Entry (deref key) (deref value) true false

--- a/stdlib/src/HashMap.an
+++ b/stdlib/src/HashMap.an
@@ -73,7 +73,8 @@ HashMap.insert (map: mut HashMap k v) (key: k) (value: v) {Hash k} {Eq k}: Maybe
         map.resize ((map.capacity + 1) * 2)
 
     var previous = Maybe.None
-    iter_until (map: mut HashMap k v) (key: ref k) (value: ref v) (start: Usz) (end: Usz) : Bool =
+    var first_tombstone: Maybe Usz = None
+    iter_until (map: mut HashMap k v) (key: ref k) (value: ref v) (start: Usz) (end: Usz)  : Bool =
         if start >= end then
             false
         else
@@ -85,16 +86,31 @@ HashMap.insert (map: mut HashMap k v) (key: k) (value: v) {Hash k} {Eq k}: Maybe
                     entry := Entry (deref key) (deref value) true false
                     true
                 else
-                    iter_until map key value (start + 1) end
+                    iter_until map key value (start + 1) end 
+            else if entry.tombstone then
+                if first_tombstone is None then
+                    first_tombstone := Some start
+
+                iter_until map key value (start + 1) end
             else
-                entry := Entry (deref key) (deref value) true false
+                insertion_index = match first_tombstone
+                    | Some index -> index
+                    | None -> start
+
+                insertion_entry = ptr_to_mut (offset map.entries insertion_index)
+                insertion_entry := Entry (deref key) (deref value) true false
                 true
 
     h = Usz (Hash.hash (deref (ref key))) % map.capacity
 
     if not iter_until map key value h map.capacity then
         if not iter_until map key value 0 h then
-            panic "Failed to insert entry into map"
+            match first_tombstone
+            | Some index ->
+                entry = ptr_to_mut (offset map.entries index)
+                entry := Entry (deref key) (deref value) true false
+            | None ->
+                panic "Failed to insert entry into map"
 
     if previous is None then
         map.len := map.len + 1usz
@@ -121,8 +137,11 @@ HashMap.get_entry_mut (map: mut HashMap k v) (key: ref k) {Hash k} {eq: Eq k}: M
         else
             entry_ptr = offset map.entries start
             entry = deref_ptr entry_ptr
-            if entry.occupied and ref entry.key == key then
-                Found entry_ptr
+            if entry.occupied then
+                if ref entry.key == key then
+                    Found entry_ptr
+                else
+                    iter_until (start + 1) end
             else if entry.tombstone then
                 iter_until (start + 1) end
             else

--- a/stdlib/src/HashMap.an
+++ b/stdlib/src/HashMap.an
@@ -73,7 +73,7 @@ HashMap.insert (map: mut HashMap k v) (key: k) (value: v) {Hash k} {Eq k}: Maybe
         map.resize ((map.capacity + 1) * 2)
 
     var previous = Maybe.None
-    var first_tombstone: Maybe Usz = None
+    var first_tombstone = Maybe.None
     iter_until (map: mut HashMap k v) (key: ref k) (value: ref v) (start: Usz) (end: Usz)  : Bool =
         if start >= end then
             false


### PR DESCRIPTION
This change fixes a bug in key collisions/deletions

Take A and B where there is a collision
[n] -> A
[n+1] -> B
when A is deleted
[n] -> tombstone
[n+1] -> B
if we don't continue iterating to search for B when we see a tombstone we would get [n] -> B
[n+1] -> B
if we re-inserted B

to fix this we continue probing past collision entries during insertion to avoid creating duplicate keys. Remembering the tombstone preserves the best insertion location if the key isn't found elsewhere.

We also add some regression coverage.