### PR TITLE
Fix Unit layout consistency across backends

### DIFF
--- a/examples/codegen/unit_pointer_offset.an
+++ b/examples/codegen/unit_pointer_offset.an
@@ -1,0 +1,28 @@
+import Std.Vec.Vec, stream_imm_vec
+import Std.Stream.iter, stream_array
+
+type MyType =
+    key: U8
+    idk: Unit
+    aboolean: Bool
+    tombstone: Bool
+
+print_mytype (res: imm MyType) =
+    print res.key
+    print ", "
+    println res.aboolean
+
+main () =
+    x = Vec.of [MyType 1 () true true, MyType 2 () false false]
+    iter (imm x) print_mytype
+
+
+    println (size_of (MkType: Type Unit))
+    println (size_of (MkType: Type MyType))
+
+// args: --delete-binary --no-color
+// expected stdout:
+// 1, true
+// 2, false
+// 1
+// 4

--- a/src/codegen/llvm/mod.rs
+++ b/src/codegen/llvm/mod.rs
@@ -7,7 +7,7 @@ use inkwell::{
     module::{Linkage, Module},
     passes::PassBuilderOptions,
     targets::{CodeModel, FileType, InitializationConfig, RelocMode, Target, TargetMachine},
-    types::{BasicType, BasicTypeEnum, IntType},
+    types::{BasicType, BasicTypeEnum, IntType, StructType},
     values::{AggregateValue, BasicValue, BasicValueEnum, FunctionValue, PhiValue},
 };
 use rustc_hash::FxHashMap;
@@ -216,6 +216,7 @@ impl<'ctx> ModuleContext<'ctx> {
             },
             ConstantValue::Float(FloatConstant::F32(v)) => self.llvm.f32_type().const_float(v.0).into(),
             ConstantValue::Float(FloatConstant::F64(v)) => self.llvm.f64_type().const_float(v.0).into(),
+            ConstantValue::Tuple(values) if values.is_empty() => self.unit_value(),
             ConstantValue::Tuple(values) => {
                 let fields = mapvec(values, |v| self.lower_constant(v));
                 self.llvm.const_struct(&fields, false).into()
@@ -330,7 +331,7 @@ impl<'ctx> ModuleContext<'ctx> {
 
         let i32_type = self.llvm.i32_type();
         let ptr_type = self.llvm.ptr_type(AddressSpace::default());
-        let unit_type = self.llvm.struct_type(&[], false);
+        let unit_type = self.convert_primitive_type(PrimitiveType::Unit).into_struct_type();
 
         // Module-local globals holding argc/argv for the lifetime of the process.
         let argc_global = self.module.add_global(i32_type, None, "ante_argc");
@@ -375,7 +376,7 @@ impl<'ctx> ModuleContext<'ctx> {
         self.builder.build_store(argv_global.as_pointer_value(), argv).unwrap();
 
         let unit = self.unit_value().into();
-        let evidence = self.llvm.struct_type(&[], false).const_zero().into();
+        let evidence = self.unit_value().into();
         self.builder.build_direct_call(ante_main, &[unit, evidence], "").unwrap();
         self.builder.build_return(Some(&i32_type.const_int(0, false))).unwrap();
     }
@@ -413,6 +414,7 @@ impl<'ctx> ModuleContext<'ctx> {
     fn convert_type(&self, typ: &mir::Type) -> BasicTypeEnum<'ctx> {
         match typ {
             mir::Type::Primitive(primitive_type) => self.convert_primitive_type(*primitive_type),
+            mir::Type::Tuple(fields) if fields.is_empty() => self.unit_type().into(),
             mir::Type::Tuple(fields) => {
                 let fields = mapvec(fields.iter(), |typ| self.convert_type(typ));
                 let struct_type = self.llvm.struct_type(&fields, false);
@@ -437,7 +439,7 @@ impl<'ctx> ModuleContext<'ctx> {
     fn convert_primitive_type(&self, primitive_type: PrimitiveType) -> BasicTypeEnum<'ctx> {
         match primitive_type {
             PrimitiveType::Error => unreachable!("Cannot codegen llvm with errors"),
-            PrimitiveType::Unit => self.llvm.struct_type(&[], false).into(),
+            PrimitiveType::Unit => self.unit_type().into(),
             PrimitiveType::Bool => self.llvm.bool_type().into(),
             PrimitiveType::Pointer => self.llvm.ptr_type(AddressSpace::default()).into(),
             PrimitiveType::Char => self.llvm.i8_type().into(),
@@ -526,8 +528,12 @@ impl<'ctx> ModuleContext<'ctx> {
         }
     }
 
-    fn unit_value(&mut self) -> BasicValueEnum<'ctx> {
-        self.llvm.const_struct(&[], false).into()
+    fn unit_type(&self) -> StructType<'ctx> {
+        self.llvm.struct_type(&[self.llvm.i8_type().into()], false)
+    }
+
+    fn unit_value(&self) -> BasicValueEnum<'ctx> {
+        self.unit_type().const_zero().into()
     }
 
     fn codegen_instruction(&mut self, function: &mir::Definition, id: mir::InstructionId) {
@@ -863,6 +869,9 @@ impl<'ctx> ModuleContext<'ctx> {
 
     fn make_tuple(&mut self, fields: &[mir::Value]) -> BasicValueEnum<'ctx> {
         let fields = mapvec(fields, |field| self.lookup_value(field));
+        if fields.is_empty() {
+            return self.unit_value();
+        }
         let const_fields =
             mapvec(&fields, |field| if field.is_const() { *field } else { Self::undef_value(field.get_type()) });
         let mut tuple = self.llvm.const_struct(&const_fields, false).as_aggregate_value_enum();

--- a/src/mir/effects/effect_lowering.rs
+++ b/src/mir/effects/effect_lowering.rs
@@ -161,8 +161,8 @@ struct Context<'local> {
 
 fn is_zero_sized(typ: &Type) -> bool {
     match typ {
-        Type::Primitive(PrimitiveType::Unit | PrimitiveType::NoClosureEnv) => true,
-        Type::Tuple(fields) => fields.iter().all(is_zero_sized),
+        Type::Primitive(PrimitiveType::NoClosureEnv) => true,
+        Type::Tuple(fields) => !fields.is_empty() && fields.iter().all(is_zero_sized),
         _ => false,
     }
 }

--- a/src/mir/mod.rs
+++ b/src/mir/mod.rs
@@ -965,7 +965,9 @@ impl Type {
                         max_align = a;
                     }
                 }
-                (offset + max_align - 1) & !(max_align - 1)
+                // empty tuples are emitted as one byte struct in C backend
+                // so we clamp to 1 minimum to match
+                ((offset + max_align - 1) & !(max_align - 1)).max(1)
             },
             Type::Function(_) => ptr_size,
             // This is a raw union so the tag isn't counted here
@@ -1066,7 +1068,8 @@ pub enum PrimitiveType {
 impl PrimitiveType {
     fn size_in_bytes(self, ptr_size: u32) -> u32 {
         match self {
-            PrimitiveType::Error | PrimitiveType::NoClosureEnv | PrimitiveType::Unit => 0,
+            PrimitiveType::Error | PrimitiveType::NoClosureEnv => 0,
+            PrimitiveType::Unit => 1,
             PrimitiveType::Bool => 1,
             PrimitiveType::Pointer => ptr_size,
             PrimitiveType::Char => 1,


### PR DESCRIPTION
This changes the two zero sized types ante has; empty tuples and Unit. To both be 1 sized in the llvm backend (and marked as 1 sized in MIR pass). See #263

Whilst the longer term goal (#238 ) is to be zero sized everywhere, this requires more design/a longer term approach. Right now the sizing is inconsistent between the C backend (which produces a 1 sized struct) and the LLVM backend which produces a zero sized struct. The former causes pointer arithmetic bugs as can be seen in the regression tests in this MR or in #263 .

For now, until zero sized types are implemented for the C backend (or during the MIR passthrough as aforementioned in #238), we take the simpler route to make things consistent by setting the size of each to be 1.