### PR TITLE
stdlib: take inequality operands by reference

### DIFF
--- a/stdlib/src/Prelude.an
+++ b/stdlib/src/Prelude.an
@@ -569,7 +569,7 @@ impl eq_maybe {Eq e}: Eq (Maybe e) with
 impl eq_pair {Eq a} {Eq b}: Eq (a, b) with
     (==) l r = l.first == r.first and l.second == r.second
 
-(!=) (l: t) (r: t) {Eq t} = not (l == r)
+(!=) (l: ref t) (r: ref t) {Eq t} = not (l == r)
 
 trait Not t =
     (not): fn t -> t


### PR DESCRIPTION
As said on tin, all implementations of == take references (see `trait Eq t`)
Therefore it should be safe to also change neq to take this too. Otherwise code like below fails to compile with a value moved error:
```ante
func (left: s) (right: s) {Eq s} =
    if left != right then
        println left
        println right
```