### PR TITLE
fix(#269): matching Unit variant payloads

### DIFF
--- a/examples/regressions/269_match_unit_payload.an
+++ b/examples/regressions/269_match_unit_payload.an
@@ -1,0 +1,9 @@
+main () =
+    result: Result Unit String = Ok ()
+
+    match result
+    | Ok () -> println "ok"
+    | Error error -> println error
+
+// args: --delete-binary --no-color
+// expected stdout: ok

--- a/src/mir/builder/mod.rs
+++ b/src/mir/builder/mod.rs
@@ -14,7 +14,7 @@ use crate::{
     lexer::token::{FloatKind, Integer, IntegerKind},
     mir::{
         Block, BlockId, Definition, DefinitionId, FloatConstant, FunctionType, Generic, Instruction, IntConstant, Mir,
-        TerminatorInstruction, Type, Value, next_definition_id,
+        PrimitiveType, TerminatorInstruction, Type, Value, next_definition_id,
     },
     name_resolution::Origin,
     parser::{
@@ -1898,6 +1898,7 @@ where
 
     fn extract_tag_value(&mut self, value_being_matched: Value) -> Value {
         match self.type_of_value(&value_being_matched) {
+            Type::Primitive(PrimitiveType::Unit) => Value::tag_value(0),
             Type::Primitive(_) => value_being_matched,
             Type::Tuple(fields) => {
                 if fields.is_empty() {


### PR DESCRIPTION
pattern matching a unit type in a match expression e.g.
```ante
match result
| Ok () -> println "ok"
| Error error -> println error
```
resulted in the following panic when compiling:
```
thread '<unnamed>' panicked at src/mir/validation.rs:
  Switch value type is not an integer, got `Unit`
```
digging in, I think this is because MIR generates effectively a nested match statement for the `Ok ()` pattern matching. The "discriminant" of this nested switch is of type Unit, but it creates a switch with cases of integer, something like:
```
switch Unit
| 0 -> ...
```
which causes the panic.

The fix should be to simply represent Unit in these cases as `0`
so instead we get something like
```
switch 0
| 0 -> ...
```
Again this would probably be resolved in the longer term fix in #238
to filter out zero sized types.